### PR TITLE
Add CeilSense presence sensor, plant sensor and garage door updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,165 @@
+# AGENTS.md
+
+Operating rules for AI coding agents working in this repository. Read this
+before editing ESPHome configs.
+
+## Repo at a glance
+
+- ESPHome configs for this household. Top-level `*.yaml` files are per-device
+  configs; `templates/*.yaml` are shared device templates included via
+  `packages:`.
+- ESPHome runs in Docker. Container name: `esphome` (image
+  `ptr727/esphome-nonroot:latest`). The host path
+  `/data/appdata/esphome/config` is mounted at `/config` inside the container.
+- All ESPHome CLI invocations must run **inside the container** and use
+  `/config/<file>.yaml` as the path argument.
+
+## Required validation before declaring a change "done"
+
+Whenever a device YAML or a template that's included by a device YAML is
+edited, run config validation for every affected device. If the change is in
+a template, validate at least one device that uses it (and prefer all of them
+if it's not obvious which ones consume it).
+
+```bash
+docker exec esphome esphome config /config/<device>.yaml
+```
+
+Look for `INFO Configuration is valid!` at the bottom. Any earlier `Failed
+config` block means the change is broken even if the line count looks right.
+
+`esphome config` only checks YAML schema + substitution resolution. It does
+**not** catch compile errors. If a change touches lambdas, conditional
+compilation, external components, or framework/platform versions, also run:
+
+```bash
+docker exec esphome esphome compile /config/<device>.yaml
+```
+
+Compile is slow (minutes). Reserve it for changes that could plausibly affect
+generated code. For pure YAML-shape changes (renaming entities, adjusting
+intervals, swapping substitution values that map to enum members) `config` is
+usually enough - but if in doubt, compile.
+
+## Verify component knobs before adding substitutions
+
+When wiring up a substitution that maps to an ESPHome component field with a
+constrained value set (an enum, an allowed-values list), verify the valid
+values from the component source first. ESPHome components live at
+`/data/backup/Profiles/PIETER-DESKTOP/piete/OneDrive/Source/ptr727/esphome-esphome/esphome/components/<component>/`
+on this machine - `sensor.py` / `__init__.py` / `*.py` contain the schema
+with the canonical enum. Do not rely on memory or external docs alone: enum
+membership in the user's installed ESPHome version is the only authority.
+
+Example failure to avoid: `variant: AHT21` was suggested as a valid value for
+the `aht10` platform. The component's `AHT10_VARIANTS` dict only contains
+`AHT10` and `AHT20`. `esphome config` caught it, but the right move would
+have been to grep the component first.
+
+## Apollo PLT-1B template
+
+[templates/apollo-plt-1b.yaml](templates/apollo-plt-1b.yaml) imports the full
+upstream `github://ApolloAutomation/PLT-1/Integrations/ESPHome/PLT-1B.yaml@main`
+package and surgically strips stock-provisioning. The upstream package is
+cached at `/data/appdata/esphome/cache/data/packages/8bc80dd7/Integrations/ESPHome/`
+- read those files when answering "where does Apollo set X" questions.
+
+Substitutions exposed for per-plant override:
+- `sleep_duration_hours` - first-boot value of HA "Sleep Duration" number.
+  After first boot, HA owns the value via NVS (`restore_value: true`). Changing
+  the substitution does **not** move an already-deployed device.
+- `prevent_sleep_default` (`ON` / `OFF`) - first-boot state of the HA "Prevent
+  Sleep" switch. Same NVS-wins semantics.
+- `aht_variant` (`AHT10` / `AHT20`) - AHT chip init mode. Compile-time, takes
+  effect on next flash.
+
+NVS-vs-substitution semantics matter: for any of these knobs to actually
+change behavior on a previously-deployed unit, NVS must be wiped (USB
+`esptool.py erase_flash` + reflash). OTA reflash preserves NVS.
+
+## SmartHome CeilSense template
+
+[templates/smarthome-ceilsense.yaml](templates/smarthome-ceilsense.yaml)
+assembles the device from SmartHomeShop's firmware **sub-packages**
+`github://smarthomeshop/ceilsense/ceilsense-v1/{base.yaml, packages/ld2412.yaml,
+packages/scd4x.yaml}@main` rather than the vendor's
+`ceilsense-complete-wifi-ld2412.yaml` entry point. That entry point also pulls in
+`wifi.yaml`, whose `on_boot` calls the `ble.disable` action (and brings in the
+Improv/BLE provisioning stack). Because `on_boot` is an un-id'd list, that single
+action can't be `!remove`d, so importing the entry point forces you to keep a
+BLE stack alive just to satisfy the action. Importing the sub-packages and
+supplying our own `wifi:` + boot phase 1 drops Bluetooth entirely (no
+`esp32_ble`, no Improv, no captive portal). `base.yaml` and the two sensor
+packages contain no BLE references.
+
+From `base.yaml` it then strips the cloud/project machinery: the `http_request`
+`update:` firmware-update entity, the cloud/local "Firmware Variant" `select`
+and its glue `script`, the `ble_disable_after_boot` switch (now pointless), plus
+`web_server`. `project: !remove` is safe here (unlike Konnected blaQ): nothing in
+the sub-packages references the `ESPHOME_PROJECT_NAME/VERSION` compile-time
+macros - the Software Version text sensor uses the `${project_version}`
+*substitution*, which still resolves after the block is gone.
+
+Consumed by [garage-presence-sensor.yaml](garage-presence-sensor.yaml). Tracks
+`@main` on a `0.9.0-beta` upstream, so an upstream id rename surfaces as a
+"Source for removal not found" error at `esphome config` - re-check the removed
+ids if that appears, or pin a `@<sha>`. Note this trades the vendor's maintained
+variant entry point for hand-assembling its parts: if upstream restructures
+`base.yaml`/the packages, re-diff against the current
+`ceilsense-complete-wifi-ld2412.yaml` to see what changed.
+
+## Converting vendor cloud/project firmware to local (reusable pattern)
+
+Pattern shared by Apollo PLT-1B, Konnected blaQ, and CeilSense. To convert a new
+vendor device:
+
+- **Import** the vendor's assembled *variant entry file* as a `github://...@<ref>`
+  package; add the house `time.yaml` include (and `api.yaml`/`ota.yaml`/
+  `logger.yaml` if the vendor doesn't already define those).
+- **Whole-key `!remove`** each stock provisioning/cloud/web surface that is its
+  own top-level key: `dashboard_import`, `captive_portal`, `esp32_improv`,
+  `improv_serial`, `web_server`, `update`, `http_request`.
+- **Remove-by-id** (`- id: !remove <id>`) when the unwanted thing is one item in
+  a list shared with entities you keep (e.g. a cloud `select` item, a
+  firmware-update `button`, the glue `script`, the `http_request` OTA platform).
+  ESPHome's `merge_config` (`esphome/config_helpers.py`) matches the id; a
+  dangling reference left behind only fails at `compile`, not `config`, so
+  compile once after this kind of change.
+- **Project identity / Update Manager:** prefer `esphome: project: !remove`
+  (Apollo, CeilSense). Only fall back to overriding `project_version: "0.0.0"`
+  when upstream lambdas reference the `ESPHOME_PROJECT_NAME/VERSION` macros
+  (Konnected) - grep the upstream package before removing the block.
+- **Override local env:** `wifi: ap: !remove` + `!secret` ssid/password/domain;
+  `api.encryption.key`; OTA password via `- id: !extend <ota_id>`.
+- **Keep templates minimal - identity + secrets + cloud-stripping only.** Nuanced
+  per-device tuning (I2C frequency, sensor `variant`, etc.) was tried on the
+  Apollo PLT-1B and made *no observable difference* (e.g. the SCD41/AHT humidity
+  still tracks ambient/outdoor humidity and isn't tunable away). Don't add such
+  knobs preemptively; add them only when a concrete problem demands it.
+
+## Writing style (prose, comments, docs, commits)
+
+Write like the developer who owns this repo, not like an AI assistant.
+
+- **No em-dashes.** Use a hyphen with spaces (` - `), a comma, a colon, or a new
+  sentence instead. Em-dashes read as AI-generated.
+- **ASCII only in text you author.** Don't introduce non-ASCII characters
+  (smart quotes, ellipsis glyphs, arrows, en/em-dashes, etc.) when writing prose,
+  comments, or markdown. Use plain `"`, `'`, `...`, `->`.
+- **Exception: characters that carry real meaning.** A symbol the value depends
+  on is fine and should be preserved - e.g. an Ohm sign for resistance, a degree
+  sign for temperature, or any Unicode the user deliberately added. Don't strip
+  those.
+- This applies to anything you generate: code comments, markdown, commit
+  messages, PR text. If the user adds a Unicode symbol on purpose, leave it; just
+  don't author em-dashes or decorative non-ASCII yourself.
+
+## Things to avoid
+
+- Don't claim a config change is working until `esphome config` (and, where
+  appropriate, `esphome compile`) returns success.
+- Don't invent enum values, component fields, or framework option names. Grep
+  the component source if uncertain.
+- Don't `!remove` blocks from Apollo's package without checking what depends
+  on the IDs inside - Apollo's lambdas reference IDs across files, and a
+  missing ID surfaces as a compile error, not a config error.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
 # ESPHome-Config
 
-[ESPHome](https://esphome.io) configuration, templates, and projects.
+[ESPHome](https://esphome.io) configuration, templates, and home automation projects.
 
-## Support
+## About
 
-For ESPHome support visit [Discord `#general-support`](https://discord.gg/dbwxp5R3).  
-Only file an [issue](https://github.com/ptr727/ESPHome-Config/issues) if you believe there is a bug in a [template](/templates/) or one of my projects.  
+A collection of ESPHome hardware templates and projects I use in my home automation setup.
 
 ## Templates
 
-A [collection](./templates/) of utility and device specific configuration templates.  
-Some templates are customized based on other people's work, see YML files for source references.
+A [collection](./templates/) of utility and device-specific configuration templates.
+
+Note that for devices with native ESPHome factory firmware, I opt to strip out the generic project and [Improv](https://www.improv-wifi.com/) configuration in favor of a custom configuration specific to my environment. This also cuts down on resource utilization by removing unused features.
 
 ### Device Templates
-
-#### TuyaConvert
-
-- Generic bootstrap [template](./tuya-convert.yaml) used when converting Tuya devices to ESPHome using TuyaConvert.
-- See blog [post](https://blog.insanegenius.com/2020/09/10/tuya-to-tasmota-to-esphome/) for firmware conversion details.
 
 #### Ayococr X5P WiFi Plug
 
@@ -32,7 +27,7 @@ Some templates are customized based on other people's work, see YML files for so
 
 #### Sonoff TH10/TH16 WiFi Relay
 
-- [Template](/templates/sonoff-th10.yaml) for the [Sonoff TH10](https://www.amazon.com/Sonoff-Temperature-Monitoring-Assistant-DS18B20/dp/B08DFQ2NP3) and [Sonoff TH16](https://www.amazon.com/Sonoff-Temperature-Humidity-Monitoring-Assistant/dp/B07TF5SYGL) WiFi relay.
+- [Template](./templates/sonoff-th10.yaml) for the [Sonoff TH10](https://www.amazon.com/Sonoff-Temperature-Monitoring-Assistant-DS18B20/dp/B08DFQ2NP3) and [Sonoff TH16](https://www.amazon.com/Sonoff-Temperature-Humidity-Monitoring-Assistant/dp/B07TF5SYGL) WiFi relay.
 - Follow the Tasmota [guide](https://tasmota.github.io/docs/devices/Sonoff-TH/) for flashing instructions.
 - Note: Sonoff TH10 and TH16 have been replaced by the [SONOFF TH Origin](https://itead.cc/product/sonoff-th/), see the [Tasmota Templates](https://templates.blakadder.com/sonoff_THR316.html) for pin layouts.
 
@@ -53,8 +48,8 @@ Some templates are customized based on other people's work, see YML files for so
 
 #### RocketController ASTRA DIN Controller
 
-- [Template](./templates/rocket-astra.yaml) for the [RocketController / RocketDyn ASTRA](https://rocketcontroller.com/product-category/controllers/) ESP32 DIN form factor controllers.
-- Follow the RocketController [guide](https://rocketcontroller.com/programming-astra-module-with-uart-serial-interface-for-arduino-ide-micropython-and-any-programming-language/) for flashing instructions.
+- [Template](./templates/rocket-astra.yaml) for the [RocketController / RocketDyn ASTRA](https://www.rocketcontroller.com) ESP32 DIN form factor controllers.
+- Follow the RocketController [guide](https://www.rocketcontroller.com/docs/esphome) for flashing instructions.
 
 #### Kincony KC868-ASR DIN Controller
 
@@ -69,61 +64,92 @@ Some templates are customized based on other people's work, see YML files for so
 
 #### Konnected blaQ Smart Garage Door Controller
 
-- [Template](./templates/konnected-blaq.yaml) for the [Konnected blaQ Smart Garage Door Controller](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative).
+- [Template](./templates/konnected-blaq.yaml) for the [Konnected blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative) smart garage door controller.
 - This is a Home Assistant friendly alternative to the Chamberlain myQ that [cut off HA access](https://www.home-assistant.io/blog/2023/11/06/removal-of-myq-integration/).
+- Imports Konnected's upstream [firmware package](https://github.com/konnected-io/konnected-esphome/blob/master/garage-door-GDOv2-Q.yaml) and surgically strips stock provisioning, see the [template](./templates/konnected-blaq.yaml) for details.
+
+#### Apollo PLT-1B Plant Sensor
+
+- [Template](./templates/apollo-plt-1b.yaml) for the [Apollo PLT-1B](https://apolloautomation.com/products/plt-1) plant soil sensor.
+- Imports Apollo's upstream [firmware package](https://github.com/ApolloAutomation/PLT-1/blob/main/Integrations/ESPHome/PLT-1B.yaml) and surgically strips the stock provisioning, see the [template](./templates/apollo-plt-1b.yaml) for details.
+
+#### SmartHomeShop CeilSense Presence and Air Sensor
+
+- [Template](./templates/smarthome-ceilsense.yaml) for the [SmartHomeShop CeilSense v1 Complete](https://ceilsense.nl/en/) presence sensor.
+- Imports SmartHomeShop's upstream [firmware package](https://github.com/smarthomeshop/ceilsense/blob/main/ceilsense-v1/ceilsense-complete-wifi-ld2412.yaml) and surgically strips the stock provisioning, see the [template](./templates/smarthome-ceilsense.yaml) for details.
 
 ### Utility Templates
 
+Shared building-block includes, composed via `packages:` by the device templates and per-device configs:
+
+- [`api.yaml`](./templates/api.yaml) - API with encryption and a configurable `api_reboot_timeout`.
+- [`ota.yaml`](./templates/ota.yaml) - ESPHome OTA with password.
+- [`logger.yaml`](./templates/logger.yaml) - logger configuration.
+- [`time.yaml`](./templates/time.yaml) - Home Assistant time source.
+- [`wifi.yaml`](./templates/wifi.yaml) - managed WiFi credentials from secrets.
+- [`basic.yaml`](./templates/basic.yaml) - restart button plus status, uptime, and version sensors.
+- [`common.yaml`](./templates/common.yaml) - bundles the api / ota / logger / time / wifi / basic includes for a typical device.
+- [`debug.yaml`](./templates/debug.yaml) - debug component and debug text sensors.
+- [`temperature.yaml`](./templates/temperature.yaml) - on-chip internal temperature sensor.
+- [`ethernet-sensor.yaml`](./templates/ethernet-sensor.yaml) - Ethernet IP / MAC info text sensors.
+- [`secrets.yaml`](./templates/secrets.yaml) - re-exports the root `secrets.yaml` so templates can resolve secrets.
+
+Board and component helpers:
+
 - [RGB LED Status](./templates/rgb-led-status.yaml) component. Useful for boards with only a RGB LED to use as [Status LED](https://esphome.io/components/status_led.html) component equivalent.
-- [ESP32-S3-DevKitC](/templates//esp32-s3-devkitc.yaml) devkit template, and [ESP32-S3-WROOM-2-N32R8V](./templates//esp32-s3-wroom-2-n32r8v.yaml) and [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml) board definitions for the [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html) boards. The default [`esp32-s3-devkit-c-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board only supports the `ESP32-S3-WROOM-1-N8` with 8MB Quad Flash and no PSRAM, any other board requires some customization, especially for the Octal memory boards. Includes the on-chip temperature sensor and RGB LED as status LED.
-- [WEMOS LOLIN32 Lite](./templates//wemos-lolin32-lite.yaml) devkit template for [WEMOS LOLIN32 Lite](https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite) and clone boards. Includes the LED as status LED.
-- [Adafruit ESP32-S3 Feather](./templates//adafruit-esp32-s3-feather.yaml) devkit template for the [Adafruit ESP32-S3 Feather](https://www.adafruit.com/product/5323) board. Includes the on-chip temperature sensor, RGB LED as status LED, and [MAX17048](https://www.analog.com/en/products/max17048.html) I2C battery charge monitor.
+- [ESP32-S3-DevKitC](./templates/esp32-s3-devkitc.yaml) devkit template, and [ESP32-S3-WROOM-2-N32R8V](./templates/esp32-s3-wroom-2-n32r8v.yaml) and [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml) board definitions for the [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html) boards. The default [`esp32-s3-devkit-c-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board only supports the `ESP32-S3-WROOM-1-N8` with 8MB Quad Flash and no PSRAM, any other board requires some customization, especially for the Octal memory boards. Includes the on-chip temperature sensor and RGB LED as status LED.
+- [WEMOS LOLIN32 Lite](./templates/wemos-lolin32-lite.yaml) devkit template for [WEMOS LOLIN32 Lite](https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite) and clone boards. Includes the LED as status LED.
+- [Adafruit ESP32-S3 Feather](./templates/adafruit-esp32-s3-feather.yaml) devkit template for the [Adafruit ESP32-S3 Feather](https://www.adafruit.com/product/5323) board. Includes the on-chip temperature sensor, RGB LED as status LED, and [MAX17048](https://www.analog.com/en/products/max17048.html) I2C battery charge monitor.
 
 ## Projects
 
-### Garage Fan Thermostat
+Per-device configs live in the repository root. Each sets `substitutions:` (device name, friendly name, and any per-device overrides) and pulls in a template via `packages:`.
 
-- Project [`garage-gate-fan.yaml`](./garage-gate-fan.yaml) and [`garage-door-fan.yaml`](./garage-door-fan.yaml) configs are used to control Sonoff TH10's as thermostats for cool air ventilation in my garage.
+### Plant Sensors (Apollo PLT-1B)
+
+- [`music-room-plant-sensor.yaml`](./music-room-plant-sensor.yaml), [`patio-plant-sensor.yaml`](./patio-plant-sensor.yaml), [`stairs-plant-sensor.yaml`](./stairs-plant-sensor.yaml), and [`upstairs-hallway-plant-sensor.yaml`](./upstairs-hallway-plant-sensor.yaml) use the [Apollo PLT-1B template](./templates/apollo-plt-1b.yaml).
+
+### Garage Presence and Air Sensor (CeilSense)
+
+- [`garage-presence-sensor.yaml`](./garage-presence-sensor.yaml) uses the [SmartHomeShop CeilSense template](./templates/smarthome-ceilsense.yaml) for presence, CO2, temperature, humidity, lux, and pressure in the garage.
+
+### Garage Door Controller (Konnected blaQ)
+
+- [`garage-door-controller.yaml`](./garage-door-controller.yaml) uses the [Konnected blaQ template](./templates/konnected-blaq.yaml).
+- Note: currently powered off pending an upstream investigation into self-opening incidents, see the status block in the config and [issue #29](https://github.com/ptr727/ESPHome-Config/issues/29).
+
+### Bluetooth Proxies (GL-S10)
+
+- [`office-bluetooth-proxy.yaml`](./office-bluetooth-proxy.yaml) and [`pantry-bluetooth-proxy.yaml`](./pantry-bluetooth-proxy.yaml) use the [GL-S10 Bluetooth Proxy template](./templates/gls10-bluetooth-proxy.yaml).
+
+### Garage Fan Thermostats
+
+- [`garage-door-fan-controller.yaml`](./garage-door-fan-controller.yaml) (Sonoff TH10) and [`garage-gate-fan-controller.yaml`](./garage-gate-fan-controller.yaml) (Norvi) control cool air ventilation fans in the garage based on temperature.
 - See blog [post](https://blog.insanegenius.com/2021/08/11/trying-to-keep-my-garage-cool/) for project details.
-
-### Utility Gas and Water Meter Pulse Counter
-
-- Project [`utility-pulse-counter.yaml`](./utility-pulse-counter.yaml) config is used to measure water and gas consumption from my utility meter pulse counters.
-- See blog [post](https://blog.insanegenius.com/2021/08/09/esp32-water-and-gas-utility-meter/) for project details.
 
 ### Hot Water Recirculation Pump
 
-- Project [`hot-water-recirc-pump.yaml`](./hot-water-recirc-pump.yaml) config is used to control my whole home hot water recirculation pump using a Sonoff TH10 and several temperature probes.
+- [`recirculation-pump-controller.yaml`](./recirculation-pump-controller.yaml) (Sonoff TH10) controls the whole home hot water recirculation pump using temperature probes on an interval / duration schedule.
 - See blog [post](https://blog.insanegenius.com/2020/10/11/hot-water-recirculation-pump-controller/) for project details.
 
-### TubesZB Ethernet Zigbee Coordinator
+## Usage
 
-- Project [`zigbee-coordinator.yaml`](./zigbee-coordinator.yaml) is used as my Zigbee Coordinator.
-- Customized version of the [TubesZB Ethernet Zigbee Coordinator](https://github.com/tube0013/tube_gateways/blob/main/models/current/tubeszb-cc2652-eth_usb/firmware/esphome/tubezb-cc2652p2-ethusb-2022.yaml).
-
-### Garage Fan Thermostat and Utility Gas and Water Meter Pulse Counter
-
-- Project [`utility-counter-gate-fan.yaml`](./utility-counter-gate-fan.yaml) is used as thermostat for cool air ventilation in my garage, and to measure water and gas consumption from my utility meter pulse counters.
-
-## Docker Deployment
-
-- The standard [ESPHome](https://hub.docker.com/r/esphome/esphome) container does not support running as non-root.
-- Deploy the [ESPHome-NonRoot](https://github.com/ptr727/ESPHome-NonRoot) container for non-root operation.
+- The standard [ESPHome](https://hub.docker.com/r/esphome/esphome) container does not support running as non-root. Deploy the [ESPHome-NonRoot](https://github.com/ptr727/ESPHome-NonRoot) container for non-root operation if desired.
 - Set directory permissions:
   - `sudo chown -R nonroot:users /data/appdata/esphome`
   - `sudo chmod -R ug=rwx,o=rx /data/appdata/esphome`
-- Clone Git repository in ESPHome config folder.
+- Clone Git repository in ESPHome config folder, or copy files.
   - `cd /data/appdata/esphome/config`
   - `git clone -b develop https://github.com/ptr727/ESPHome-Config .`
-- Deploy `secrets.yaml`, use `secrets._yaml` as template.
-- In VSCode open remote SSH workspace on docker host, and open workspace from config directory.
+- Deploy `secrets.yaml`, use `secrets._yaml` as a template for required secrets.
+- In VSCode open remote SSH workspace on the docker host, and open the workspace from config directory.
 
 ## Notes
 
-### General
+### Issues
 
-- Not all [templates](./templates/) are documented here.
-- I deployed Zigbee in my home using [Z2M](https://www.zigbee2mqtt.io/) and [TubesZB](https://tubeszb.com/) Zigbee Ethernet coordinator, and no longer use ESPHome flashed smart plugs. For US smart plugs I highly recommend the [Sengled](https://www.amazon.com/gp/product/B092DBFFBY/) Zigbee power monitoring smart plugs.
+- For general ESPHome support visit the [ESPHome Discord `#general-support`](https://discord.gg/dbwxp5R3).
+- Only file an [issue](https://github.com/ptr727/ESPHome-Config/issues) if you believe there is a bug in a [template](./templates/) or one of my projects.
 
 ### Espressif32 and Framework Versions
 

--- a/garage-door-controller.yaml
+++ b/garage-door-controller.yaml
@@ -1,19 +1,52 @@
-# STATUS (2026-05-13): Controller is physically powered off. Do not re-energize
-# or re-flash until the upstream gdolib v1.1.0 spurious-trigger regression is
-# resolved. See:
-#   - https://github.com/ptr727/ESPHome-Config/issues/29
-#   - https://github.com/konnected-io/konnected-esphome/issues/93
+# STATUS (2026-05-13): Controller is physically powered off. Root cause for
+# the two observed self-opening incidents is NOT confirmed. Do not re-energize
+# or re-flash until upstream investigation closes. See:
+#   - https://github.com/ptr727/ESPHome-Config/issues/29        (incident report)
+#   - https://github.com/konnected-io/konnected-esphome/issues/112 (filed upstream)
+#   - https://github.com/konnected-io/konnected-esphome/issues/93  (similar pattern, older)
 #   - templates/konnected-blaq.yaml (pin comment)
-# Two distinct hazards stack here:
-#   1. Boot-window: GPIO1 (Sec+ UART TX) is uncontrolled between esp_restart()
-#      and secplus_gdo::setup(). The upstream component clamps it inside the
-#      panic handler only, not on clean reboots — so every reboot is a chance
-#      for a spurious wall-button press to be decoded by the opener.
-#   2. Runtime (gdolib v1.1.0): the new gdo_door_move_to_target() routes
-#      through gdo_door_open/close, which can issue a direct OPEN or CLOSE
-#      command on the Sec+ wire at runtime. Pin in konnected-blaq.yaml
-#      reverts gdolib to v1.0.0, but before re-flashing the Sec+ wire MUST
-#      be physically disconnected from the opener terminals to avoid (1).
+#
+# Initial theories, with corrections from Konnected maintainer
+# (heythisisnate, konnected-io/konnected-esphome#112):
+#
+#   Hazard A — Boot-window GPIO1 UART glitch
+#     Theory: GPIO1 (Sec+ UART TX) is uncontrolled between esp_restart() and
+#     secplus_gdo::setup(); a stray pulse could be decoded as a wall-button
+#     press.
+#     Maintainer correction: this mechanism only triggers on Security+ 1.0
+#     openers (those latch on momentary low pulses). This is a Sec+ 2.0
+#     opener (LiftMaster 8500, yellow learn button), which does NOT trigger
+#     on a momentary pull to low or contact closure. So this theory does
+#     not explain either incident on this device.
+#
+#   Hazard B — gdolib v1.1.0 gdo_door_move_to_target() rewrite
+#     Theory: the new routing through gdo_door_open/close could send a
+#     direct OPEN/CLOSE on the Sec+ wire.
+#     Maintainer correction: gdolib v1.1.0's only changes are inside
+#     gdo_door_move_to_target. If nothing called that function (e.g. no HA
+#     "set position to X%" command), it cannot have been the cause.
+#     Incident 1 happened while HA was disconnected, so move_to_target
+#     could not have been invoked. Incident 2 happened during/after an OTA
+#     with no manual set-position command. So this theory is also
+#     unconfirmed.
+#
+# What we actually know:
+#   - Two spurious openings correlated in time with reboots/OTAs.
+#   - Powering the blaQ off during Incident 2 immediately stopped the
+#     opener's diagnostic flashing and beeping — evidence the controller
+#     was actively driving the Sec+ wire in steady state, not just
+#     glitching once at boot.
+#   - The mechanism for a Sec+ 2.0 opener to be driven this way during
+#     boot/reboot remains unexplained.
+#
+# Mitigations applied here are defense-in-depth and remain reasonable
+# regardless of which theory turns out correct:
+#   - api.reboot_timeout / wifi.reboot_timeout = 0s: stops the 15-min
+#     reboot loop that exposed Incident 1's many reboot cycles to chance.
+#   - Pin upstream YAML to @501c37e (gdolib v1.0.0): reverts the v1.1.0
+#     code path even though it's not confirmed to be the cause.
+#   - project_name / project_version override in konnected-blaq.yaml:
+#     blocks the ESPHome Update Manager from force-flashing.
 
 # https://esphome.io/guides/configuration-types.html#substitutions
 substitutions:

--- a/garage-presence-sensor.yaml
+++ b/garage-presence-sensor.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  device_name: garage-presence-sensor
+  device_friendly_name: "Garage Presence Sensor"
+
+packages:
+  ceilsense: !include templates/smarthome-ceilsense.yaml

--- a/music-room-plant-sensor.yaml
+++ b/music-room-plant-sensor.yaml
@@ -1,7 +1,7 @@
 # https://esphome.io/guides/configuration-types.html#substitutions
 substitutions:
-  device_name: patio-plant-sensor
-  device_friendly_name: "Patio Plant Sensor"
+  device_name: music-room-plant-sensor
+  device_friendly_name: "Music Room Plant Sensor"
   sleep_duration_hours: "1"
   prevent_sleep_default: "ON"
 

--- a/stairs-plant-sensor.yaml
+++ b/stairs-plant-sensor.yaml
@@ -1,7 +1,7 @@
 # https://esphome.io/guides/configuration-types.html#substitutions
 substitutions:
-  device_name: patio-plant-sensor
-  device_friendly_name: "Patio Plant Sensor"
+  device_name: stairs-plant-sensor
+  device_friendly_name: "Stairs Plant Sensor"
   sleep_duration_hours: "1"
   prevent_sleep_default: "ON"
 

--- a/templates/apollo-plt-1b.yaml
+++ b/templates/apollo-plt-1b.yaml
@@ -13,6 +13,13 @@ substitutions:
   # Apollo's PLT-1B.yaml expects these for esphome.name / friendly_name
   name: ${device_name}
   friendly_name: ${device_friendly_name}
+  # Apollo's Core.yaml defines `version: "26.3.2.1"` and PLT-1B.yaml threads
+  # it into both `esphome.project.version` (removed below) and the
+  # `apollo_firmware_version` text_sensor state. Override to a static local
+  # value so the ESPHome Update Manager (EUM) has nothing to compare
+  # against and the firmware version sensor reports a fork-owned string.
+  # See: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
+  version: "0.0.0"
 
 # https://esphome.io/components/esphome
 esphome:
@@ -21,6 +28,14 @@ esphome:
   name_add_mac_suffix: false
   # Apollo's PLT-1B.yaml hardcodes `comment: Apollo PLT-1B`; drop it.
   comment: !remove
+  # Remove Apollo's `project:` block (name=ApolloAutomation.PLT-1B,
+  # version=${version}) so EUM cannot see an upstream project identity to
+  # force-install updates against. Safe here because Apollo's upstream
+  # never references ESPHOME_PROJECT_NAME / ESPHOME_PROJECT_VERSION macros
+  # (verified: no hits across Integrations/ESPHome/). The konnected-blaq
+  # template can't do the same because Konnected's core-esp32-s3.yaml and
+  # mdns.yaml reference those macros in lambdas.
+  project: !remove
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:

--- a/templates/apollo-plt-1b.yaml
+++ b/templates/apollo-plt-1b.yaml
@@ -3,38 +3,31 @@
 # device_friendly_name
 
 # Apollo PLT-1B Plant Sensor
-# Imports Apollo's full firmware package and surgically strips stock-provisioning
-# concerns. Mirrors the pattern in templates/konnected-blaq.yaml.
 # https://apolloautomation.com/products/plt-1
 # https://github.com/ApolloAutomation/PLT-1
 # https://wiki.apolloautomation.com/products/plt1b/introduction/
+# https://wiki.apolloautomation.com/products/plt1/examples/flower-card/
+
+# Imports Apollo's full firmware package and surgically strips stock-provisioning concerns.
 
 substitutions:
   # Apollo's PLT-1B.yaml expects these for esphome.name / friendly_name
   name: ${device_name}
   friendly_name: ${device_friendly_name}
-  # Apollo's Core.yaml defines `version: "26.3.2.1"` and PLT-1B.yaml threads
-  # it into both `esphome.project.version` (removed below) and the
-  # `apollo_firmware_version` text_sensor state. Override to a static local
-  # value so the ESPHome Update Manager (EUM) has nothing to compare
-  # against and the firmware version sensor reports a fork-owned string.
-  # See: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
+  # Remove project versions so ESPHome Update Manager does not auto update
+  # TODO: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
   version: "0.0.0"
+  # Default sleep duration and prevent sleep state if not already set in NVS, else HA owns runtime config.
+  sleep_duration_hours: "12"
+  prevent_sleep_default: "ON"
 
 # https://esphome.io/components/esphome
 esphome:
   name: ${device_name}
   friendly_name: ${device_friendly_name}
   name_add_mac_suffix: false
-  # Apollo's PLT-1B.yaml hardcodes `comment: Apollo PLT-1B`; drop it.
   comment: !remove
-  # Remove Apollo's `project:` block (name=ApolloAutomation.PLT-1B,
-  # version=${version}) so EUM cannot see an upstream project identity to
-  # force-install updates against. Safe here because Apollo's upstream
-  # never references ESPHOME_PROJECT_NAME / ESPHOME_PROJECT_VERSION macros
-  # (verified: no hits across Integrations/ESPHome/). The konnected-blaq
-  # template can't do the same because Konnected's core-esp32-s3.yaml and
-  # mdns.yaml reference those macros in lambdas.
+  # Remove Apollo's `project:` block
   project: !remove
 
 # https://esphome.io/guides/configuration-types.html#packages
@@ -43,11 +36,6 @@ packages:
   time: !include time.yaml
 
 # Strip stock-firmware provisioning + the HA-side update entity.
-# We do NOT !remove `http_request:` or the `ota:` block as a whole because
-# Apollo's `ota:` includes a `platform: http_request` entry (id: ota_managed)
-# that requires `http_request:` to compile. Removing `update:` is enough to
-# kill the misleading "update available" HA entity that pointed at Apollo's
-# stock-firmware manifest.
 dashboard_import: !remove
 improv_serial:    !remove
 esp32_improv:     !remove
@@ -66,20 +54,26 @@ wifi:
   min_auth_mode: WPA2
 
 # Extend Apollo's existing esphome OTA entry (id: ota_esphome) to add our password.
-# Apollo's other OTA platform (http_request, id: ota_managed) sits inert without `update:`.
 ota:
   - id: !extend ota_esphome
     password: !secret ota_password
 
-# Extend Apollo's api: with encryption (merges with their reboot_timeout,
-# on_client_connected handler, and play_buzzer action)
+# Extend Apollo's api: with encryption
 api:
   encryption:
     key: !secret api_encryption_key
 
+# Seed Apollo's HA-exposed "Sleep Duration" number with our default first-boot value.
+number:
+  - id: !extend deep_sleep_sleep_duration
+    initial_value: ${sleep_duration_hours}
+
+# Seed Apollo's HA-exposed "Prevent Sleep" switch with our default first-boot state.
+switch:
+  - id: !extend prevent_sleep
+    restore_mode: RESTORE_DEFAULT_${prevent_sleep_default}
+
 # Match templates/basic.yaml convention for the Apollo-supplied uptime + status sensors.
-# Apollo's text_sensor.version and button.restart have no upstream id so they keep
-# their names "ESPHome Version" / "ESP Reboot".
 sensor:
   - id: !extend sys_uptime
     name: "Uptime"

--- a/templates/konnected-blaq.yaml
+++ b/templates/konnected-blaq.yaml
@@ -7,27 +7,16 @@
 # https://github.com/konnected-io/konnected-esphome/blob/master/garage-door-GDOv2-Q.yaml
 # https://github.com/konnected-io/konnected-esphome/tree/master/components/secplus_gdo
 
-# WARNING Using `cover.COVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0.
-# Please use `cover.cover_schema(...)` instead.
-# WARNING Using `lock.LOCK_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0.
-# Please use `lock.lock_schema(...)` instead.
-# If you are seeing this, report an issue to the external_component author and ask them to update it.
-# https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/.
-# Component using this schema: secplus_gdo
+# Imports Konneckted's full firmware package and surgically strips stock-provisioning concerns.
 
 substitutions:
   # Used by garage-door-GDOv2-Q.yaml
   name: ${device_name}
   friendly_name: ${device_friendly_name}
-  # Per-device override; 0s disables wifi-loss reboot loops on the
-  # Sec+ garage controller (boot-window UART glitch hazard).
+  # Per-device override; 0s disables reboot loop that can result in sec1+ UART glitch opening the door.
   wifi_reboot_timeout: 15min
-  # Override upstream's project_name / project_version so the ESPHome
-  # Update Manager (EUM) has no upstream-controlled version to compare
-  # against. Defense in depth alongside the @501c37e pin below: even if
-  # the pin is moved or removed, EUM's force-install path cannot fire
-  # for this device because yaml_v will never exceed device_v. See:
-  #   https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
+  # Remove project versions so ESPHome Update Manager does not auto update
+  # TODO: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
   #
   # NOTE: we cannot `!remove` the entire `esphome.project:` block here the
   # way templates/apollo-plt-1b.yaml does. Konnected's upstream packages
@@ -63,8 +52,8 @@ packages:
   # Konnected maintainer's reply at konnected-io/konnected-esphome#112
   # narrows the field of candidate causes:
   #   - The "GPIO1 boot-window UART glitch" theory applies only to
-  #     Security+ 1.0 openers. This is a Sec+ 2.0 (LiftMaster 8500,
-  #     yellow learn button), so that mechanism is ruled out here.
+  #     Security+ 1.0 openers. This is a Sec+ 1.0 (LiftMaster 8500,
+  #     square learn button).
   #   - gdolib v1.1.0's only changes are inside gdo_door_move_to_target;
   #     it cannot misbehave unless that function is called. Incident 1
   #     had HA disconnected (no caller possible) and Incident 2 had no
@@ -84,8 +73,6 @@ packages:
   logger: !include logger.yaml
   ota: !include ota.yaml
   time: !include time.yaml
-  # TODO: Is there a way to include packages again after removing some items?
-  # wifi: !include wifi.yaml
 
 # Remove unwanted items included by gdov2q package
 esp32_improv: !remove

--- a/templates/konnected-blaq.yaml
+++ b/templates/konnected-blaq.yaml
@@ -22,6 +22,28 @@ substitutions:
   # Per-device override; 0s disables wifi-loss reboot loops on the
   # Sec+ garage controller (boot-window UART glitch hazard).
   wifi_reboot_timeout: 15min
+  # Override upstream's project_name / project_version so the ESPHome
+  # Update Manager (EUM) has no upstream-controlled version to compare
+  # against. Defense in depth alongside the @501c37e pin below: even if
+  # the pin is moved or removed, EUM's force-install path cannot fire
+  # for this device because yaml_v will never exceed device_v. See:
+  #   https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
+  #
+  # NOTE: we cannot `!remove` the entire `esphome.project:` block here the
+  # way templates/apollo-plt-1b.yaml does. Konnected's upstream packages
+  # reference the compile-time macros `ESPHOME_PROJECT_NAME` and
+  # `ESPHOME_PROJECT_VERSION` from lambdas:
+  #   - packages/core-esp32-s3.yaml on_boot:
+  #       state: !lambda return ESPHOME_PROJECT_VERSION;
+  #   - packages/mdns.yaml:
+  #       project_name:    !lambda return ESPHOME_PROJECT_NAME;
+  #       project_version: !lambda return ESPHOME_PROJECT_VERSION;
+  # Those macros are only defined when `esphome.project:` is set, so
+  # removing it produces an unresolvable compile error in upstream files
+  # we can't easily patch. Apollo's PLT-1B.yaml references neither macro,
+  # which is why a `!remove` is safe there.
+  project_name: "ptr727.${device_name}"
+  project_version: "0.0.0"
 
 # https://esphome.io/components/esphome
 esphome:
@@ -33,18 +55,30 @@ esphome:
 packages:
   # https://github.com/konnected-io/konnected-esphome/blob/master/garage-door-GDOv2-Q.yaml
   #
-  # PINNED to commit 501c37e (2026-05-07, gdolib v1.0.0). Do NOT move back to
-  # @master until the gdolib v1.1.0 spurious-trigger regression is fixed
-  # upstream. Tracking:
-  #   - https://github.com/ptr727/ESPHome-Config/issues/29
-  #     (door opened by itself; mechanism analysis)
-  #   - https://github.com/konnected-io/konnected-esphome/issues/93
-  #     (independent corroboration: random reboots + spurious openings)
+  # PINNED to commit 501c37e (2026-05-07, gdolib v1.0.0). This pin is
+  # defense-in-depth, not a confirmed fix: the root cause of the two
+  # self-opening incidents on 2026-05-13 is NOT established. See the
+  # STATUS block at the top of garage-door-controller.yaml.
+  #
+  # Konnected maintainer's reply at konnected-io/konnected-esphome#112
+  # narrows the field of candidate causes:
+  #   - The "GPIO1 boot-window UART glitch" theory applies only to
+  #     Security+ 1.0 openers. This is a Sec+ 2.0 (LiftMaster 8500,
+  #     yellow learn button), so that mechanism is ruled out here.
+  #   - gdolib v1.1.0's only changes are inside gdo_door_move_to_target;
+  #     it cannot misbehave unless that function is called. Incident 1
+  #     had HA disconnected (no caller possible) and Incident 2 had no
+  #     manual set-position command, so this is unconfirmed too.
+  # Tracking:
+  #   - https://github.com/ptr727/ESPHome-Config/issues/29           (incident report)
+  #   - https://github.com/konnected-io/konnected-esphome/issues/112 (filed upstream)
+  #   - https://github.com/konnected-io/konnected-esphome/issues/93  (similar pattern, older)
   #   - https://github.com/konnected-io/konnected-esphome/commit/536e2dd
-  #     (the upstream commit that bumped gdolib v1.0.0 -> v1.1.0 and
-  #     rewrote gdo_door_move_to_target to route through gdo_door_open /
-  #     gdo_door_close — meaning a "set position" call can issue a direct
-  #     OPEN/CLOSE on the Sec+ wire at runtime)
+  #     (the commit that bumped gdolib v1.0.0 -> v1.1.0)
+  # The pin reverts gdolib to v1.0.0 in case the maintainer's audit of the
+  # move_to_target rewrite finds a path that fires without an explicit
+  # caller. Cheap to keep, easy to undo once the upstream investigation
+  # closes.
   gdov2q: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@501c37e
   api: !include api.yaml
   logger: !include logger.yaml

--- a/templates/smarthome-ceilsense.yaml
+++ b/templates/smarthome-ceilsense.yaml
@@ -1,0 +1,130 @@
+# Required substitutions:
+# device_name
+# device_friendly_name
+
+# SmartHomeShop CeilSense v1 Complete (WiFi, LD2412 + SCD4x)
+# https://ceilsense.nl/en/
+# https://docs.smarthomeshop.io/en/ceilsense/ceilsense-index-en
+# https://github.com/smarthomeshop/ceilsense
+# https://github.com/smarthomeshop/ceilsense/tree/main/ceilsense-v1
+
+# Imports SmartHomeShop's firmware sub-packages and surgically strips the
+# cloud-app / project-based-OTA / stock-provisioning concerns.
+#
+# We assemble the device from base.yaml + the ld2412 + scd4x packages directly
+# instead of importing the vendor's `ceilsense-complete-wifi-ld2412.yaml` entry
+# point. That entry point also pulls in `wifi.yaml`, whose on_boot calls the
+# `ble.disable` action and pulls in the Improv/BLE provisioning stack. on_boot
+# entries are an un-id'd list, so a single one can't be `!remove`d; importing the
+# sub-packages and supplying our own `wifi:` + boot phase lets us drop Bluetooth
+# entirely (no esp32_ble, no Improv, no captive portal) rather than disabling it
+# after boot. base.yaml + the two sensor packages contain no BLE references.
+
+substitutions:
+  # base.yaml expects these for esphome.name / friendly_name
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+
+# https://esphome.io/components/esphome
+esphome:
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+  name_add_mac_suffix: false
+  # Remove SmartHomeShop's `project:` block so ESPHome Update Manager does not
+  # auto update. Safe here: nothing in base/ld2412/scd4x references the
+  # ESPHOME_PROJECT_NAME/VERSION compile-time macros (the Software Version text
+  # sensor uses the `${project_version}` substitution, not the macro), unlike
+  # templates/konnected-blaq.yaml which must keep the block and override the
+  # version substitution instead.
+  # TODO: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
+  project: !remove
+  # Replacement for wifi.yaml's boot phase 1 (which we no longer import), minus
+  # the BLE bits: start the status-LED loading animation and wait for WiFi. The
+  # remaining self-test phases (LD2412 / SCD4x / BH1750 / BMP3xx) come from the
+  # sub-packages' own on_boot entries.
+  on_boot:
+    - priority: 600
+      then:
+        - lambda: 'id(startup_phase) = 1;'
+        - light.turn_on:
+            id: status_led
+            brightness: 80%
+            effect: "Circular Loading Effect"
+        - wait_until:
+            condition:
+              wifi.connected:
+            timeout: 30s
+
+# https://esphome.io/guides/configuration-types.html#packages
+# The vendor's complete-wifi-ld2412 variant is just base.yaml + these two sensor
+# packages + wifi.yaml; we take all but wifi.yaml (see header) and add our own.
+packages:
+  base:   github://smarthomeshop/ceilsense/ceilsense-v1/base.yaml@main
+  ld2412: github://smarthomeshop/ceilsense/ceilsense-v1/packages/ld2412.yaml@main
+  scd4x:  github://smarthomeshop/ceilsense/ceilsense-v1/packages/scd4x.yaml@main
+  time: !include time.yaml
+
+# Strip the web UI + the HA-side http_request firmware-update entity (whole-key
+# removals from base.yaml).
+web_server:   !remove
+update:       !remove   # http_request firmware-update entity (id: firmware_update)
+http_request: !remove   # only consumed by `update` + the ota_http_request platform, both removed
+
+# Extend base.yaml's esphome OTA entry (id: ota_esphome) to add our password,
+# and drop the http_request OTA platform (depends on the removed http_request).
+ota:
+  - id: !extend ota_esphome
+    password: !secret ota_password
+  - id: !remove ota_http_request
+
+# Extend base.yaml's bare api: with encryption.
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+# Remove the cloud/local "Firmware Variant" selector. Removed by id, not as a
+# whole key, because packages/ld2412.yaml adds its own selects to this list.
+select:
+  - id: !remove firmware_selector
+
+# Remove the "CeilSense Firmware Update" button. Removed by id so the restart /
+# factory-reset / LD2412 / SCD4x buttons in the same list stay.
+button:
+  - id: !remove update_firmware
+
+# Remove the glue script that drives the firmware selector/update (references
+# firmware_selector + firmware_update, both removed above).
+script:
+  - id: !remove sync_selected_firmware_source
+
+# Remove base.yaml's "Disable Bluetooth after boot" switch - it only gated
+# wifi.yaml's now-absent ble.disable call, and we run no Bluetooth at all. The
+# "LD2412 Debug Mode" switch in the same list stays.
+switch:
+  - id: !remove ble_disable_after_boot
+
+# Local-environment WiFi (base.yaml supplies no wifi: of its own).
+wifi:
+  ssid:     !secret wifi_ssid
+  password: !secret wifi_password
+  domain:   !secret wifi_domain
+  reboot_timeout: 15min
+  min_auth_mode: WPA2
+
+# Match templates/basic.yaml convention: Uptime in minutes + API-connected
+# Status, plus the WiFi Signal diagnostic that wifi.yaml used to provide.
+sensor:
+  - platform: uptime
+    name: "Uptime"
+    unit_of_measurement: min
+    filters:
+      - lambda: return x / 60.0;
+  - platform: wifi_signal
+    name: "WiFi Signal"
+    update_interval: 60s
+    entity_category: diagnostic
+    disabled_by_default: true
+
+binary_sensor:
+  - platform: status
+    name: "Status"

--- a/upstairs-hallway-plant-sensor.yaml
+++ b/upstairs-hallway-plant-sensor.yaml
@@ -1,7 +1,7 @@
 # https://esphome.io/guides/configuration-types.html#substitutions
 substitutions:
-  device_name: patio-plant-sensor
-  device_friendly_name: "Patio Plant Sensor"
+  device_name: upstairs-hallway-plant-sensor
+  device_friendly_name: "Upstairs Hallway Plant Sensor"
   sleep_duration_hours: "1"
   prevent_sleep_default: "ON"
 


### PR DESCRIPTION
Merges the current `develop` work into `main`. Three commits:

## Add SmartHomeShop CeilSense template and garage presence sensor (93cae0a)
- New `templates/smarthome-ceilsense.yaml` deriving from SmartHomeShop's upstream firmware sub-packages (`base` + `ld2412` + `scd4x`), stripping the cloud-app onboarding, project-based OTA / firmware selector, web server, and Bluetooth / Improv stack while injecting managed WiFi / API / OTA secrets.
- Assembles from sub-packages rather than the vendor's variant entry point so Bluetooth is omitted entirely, saving ~305 KB flash and ~10 KB RAM versus keeping `esp32_ble` just to satisfy `wifi.yaml`'s `ble.disable` on_boot action.
- New `garage-presence-sensor.yaml` device config consuming the template. Validated with `esphome config` + `esphome compile`, and confirmed working on hardware (presence, CO2, temperature, humidity, lux, pressure).
- New `AGENTS.md`: CeilSense template notes, a reusable cloud-to-local conversion playbook, and a writing-style convention (no em-dashes, ASCII-only prose).
- `README.md` refresh: document the Apollo PLT-1B and CeilSense templates and all shared utility includes, rewrite the Projects section to match current device configs, fix stale/broken links, and remove the dead TuyaConvert section.

## Prior commits also included
- Plant sensor configs for music room, stairs, and upstairs hallway; sleep settings and friendly names (8f1d124).
- Garage door controller and Apollo PLT-1B documentation, status updates, and version overrides to prevent upstream conflicts (3848d7b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)