### PR TITLE
Add source lint gate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown uses trailing whitespace (two spaces) for hard line breaks.
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,10 @@
+{
+  "Disable": {
+    "Charset": true,
+    "Indentation": true,
+    "IndentSize": true,
+    "TrimTrailingWhitespace": true,
+    "InsertFinalNewline": true,
+    "MaxLineLength": true
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Leave line endings alone; .editorconfig + CI (editorconfig-checker) enforce LF.
+# git config --global core.autocrlf false
+# git add --renormalize .
+# git ls-files --eol
+* -text

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,15 +28,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Lint Markdown step
-        run: docker run --rm -v "$PWD":/workdir davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 "**/*.md" # markdownlint-cli2 v0.22.1
+        run: docker run --rm -v "$PWD":/workdir --workdir /workdir davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 "**/*.md" # markdownlint-cli2 v0.22.1
 
       - name: Lint workflows step
         run: docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color # actionlint v1.7.12

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,0 +1,53 @@
+name: Test pull request action
+
+# Lint gate for a configuration/community-health repository (no build or tests). check-workflow-status is the
+# ruleset-bound required check - do NOT rename it independently of the branch ruleset.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # Source lint: markdownlint (docs), actionlint (workflows), and editorconfig-checker (line endings only - other
+  # checks are disabled in .editorconfig-checker.json), all digest-pinned. cspell is a deliberate follow-up.
+  lint:
+    name: Lint sources job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout code step
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Lint Markdown step
+        run: docker run --rm -v "$PWD":/workdir davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 "**/*.md" # markdownlint-cli2 v0.22.1
+
+      - name: Lint workflows step
+        run: docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color # actionlint v1.7.12
+
+      - name: Check line endings step
+        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00 # editorconfig-checker v3.4.0
+
+  # GitHub Actions cannot put a required status check on a conditional job, so a single always-run aggregator gates
+  # the merge. Its name is the ruleset-bound required status-check context - rename it and the ruleset together.
+  check-workflow-status:
+    name: Check pull request workflow status
+    runs-on: ubuntu-latest
+    needs: [ lint ]
+    if: always()
+    steps:
+      - name: Check workflow results step
+        run: |
+          set -euo pipefail
+          if [[ "${{ needs.lint.result }}" != "success" ]]; then
+            echo "Job 'lint' did not succeed (${{ needs.lint.result }}); refusing to pass."
+            exit 1
+          fi

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,15 @@
+{
+    "config": {
+        // Prose paragraphs and data-heavy tables/URLs are intentionally long;
+        // reflowing at 80 cols hurts readability and churns diffs.
+        "MD013": false,
+        // Inline HTML is used for reference-link section dividers.
+        "MD033": false,
+        // Require fenced code blocks over the legacy 4-space-indented style.
+        "MD046": { "style": "fenced" },
+        // MD060 (table column style) is not enforced - allow both compact
+        // (`|a|b|`) and padded (`| a | b |`) table pipe spacing.
+        "MD060": false
+    },
+    "gitignore": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,11 @@ have been to grep the component first.
 upstream `github://ApolloAutomation/PLT-1/Integrations/ESPHome/PLT-1B.yaml@main`
 package and surgically strips stock-provisioning. The upstream package is
 cached at `/data/appdata/esphome/cache/data/packages/8bc80dd7/Integrations/ESPHome/`
+
 - read those files when answering "where does Apollo set X" questions.
 
 Substitutions exposed for per-plant override:
+
 - `sleep_duration_hours` - first-boot value of HA "Sleep Duration" number.
   After first boot, HA owns the value via NVS (`restore_value: true`). Changing
   the substitution does **not** move an already-deployed device.


### PR DESCRIPTION
Onboards ESPHome-Config to the fleet lint gate (config-repo onboarding).

## What

- `.github/workflows/test-pull-request.yml` — `Lint sources job` (markdownlint + actionlint + editorconfig-checker, digest-pinned) gated by the always-run `Check pull request workflow status` aggregator (the ruleset-bound required check). **No yamllint** — ESPHome YAML uses `!secret`/`!lambda` and package includes that generic YAML linters reject.
- `.editorconfig` — `[*] end_of_line = lf` (57 yaml + configs verified LF; zero churn).
- `.gitattributes`, `.markdownlint-cli2.jsonc`, `.editorconfig-checker.json`.

## Markdown fixes (markdownlint --fix, formatting only)

`AGENTS.md` and `.github/ISSUE_TEMPLATE/bug_report.md`: blank lines around lists (MD032) + list indentation (MD007). Renders identically.

All three linters pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)