### PR TITLE
Promote develop to main

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown uses trailing whitespace (two spaces) for hard line breaks.
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,10 @@
+{
+  "Disable": {
+    "Charset": true,
+    "Indentation": true,
+    "IndentSize": true,
+    "TrimTrailingWhitespace": true,
+    "InsertFinalNewline": true,
+    "MaxLineLength": true
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Leave line endings alone; .editorconfig + CI (editorconfig-checker) enforce LF.
+# git config --global core.autocrlf false
+# git add --renormalize .
+# git ls-files --eol
+* -text

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,15 +28,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,0 +1,53 @@
+name: Test pull request action
+
+# Lint gate for a configuration/community-health repository (no build or tests). check-workflow-status is the
+# ruleset-bound required check - do NOT rename it independently of the branch ruleset.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # Source lint: markdownlint (docs), actionlint (workflows), and editorconfig-checker (line endings only - other
+  # checks are disabled in .editorconfig-checker.json), all digest-pinned. cspell is a deliberate follow-up.
+  lint:
+    name: Lint sources job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout code step
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Lint Markdown step
+        run: docker run --rm -v "$PWD":/workdir --workdir /workdir davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 "**/*.md" # markdownlint-cli2 v0.22.1
+
+      - name: Lint workflows step
+        run: docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color # actionlint v1.7.12
+
+      - name: Check line endings step
+        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00 # editorconfig-checker v3.4.0
+
+  # GitHub Actions cannot put a required status check on a conditional job, so a single always-run aggregator gates
+  # the merge. Its name is the ruleset-bound required status-check context - rename it and the ruleset together.
+  check-workflow-status:
+    name: Check pull request workflow status
+    runs-on: ubuntu-latest
+    needs: [ lint ]
+    if: always()
+    steps:
+      - name: Check workflow results step
+        run: |
+          set -euo pipefail
+          if [[ "${{ needs.lint.result }}" != "success" ]]; then
+            echo "Job 'lint' did not succeed (${{ needs.lint.result }}); refusing to pass."
+            exit 1
+          fi

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,15 @@
+{
+    "config": {
+        // Prose paragraphs and data-heavy tables/URLs are intentionally long;
+        // reflowing at 80 cols hurts readability and churns diffs.
+        "MD013": false,
+        // Inline HTML is used for reference-link section dividers.
+        "MD033": false,
+        // Require fenced code blocks over the legacy 4-space-indented style.
+        "MD046": { "style": "fenced" },
+        // MD060 (table column style) is not enforced - allow both compact
+        // (`|a|b|`) and padded (`| a | b |`) table pipe spacing.
+        "MD060": false
+    },
+    "gitignore": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,11 @@ have been to grep the component first.
 upstream `github://ApolloAutomation/PLT-1/Integrations/ESPHome/PLT-1B.yaml@main`
 package and surgically strips stock-provisioning. The upstream package is
 cached at `/data/appdata/esphome/cache/data/packages/8bc80dd7/Integrations/ESPHome/`
+
 - read those files when answering "where does Apollo set X" questions.
 
 Substitutions exposed for per-plant override:
+
 - `sleep_duration_hours` - first-boot value of HA "Sleep Duration" number.
   After first boot, HA owns the value via NVS (`restore_value: true`). Changing
   the substitution does **not** move an already-deployed device.

--- a/garage-door-controller.yaml
+++ b/garage-door-controller.yaml
@@ -1,50 +1,44 @@
-# STATUS (2026-05-13): Controller is physically powered off. Root cause for
-# the two observed self-opening incidents is NOT confirmed. Do not re-energize
-# or re-flash until upstream investigation closes. See:
-#   - https://github.com/ptr727/ESPHome-Config/issues/29        (incident report)
+# STATUS (2026-06-08): Controller remains physically POWERED OFF, intentionally.
+# Root cause CONFIRMED: the two self-opening incidents were caused by the
+# boot-window GPIO1 UART glitch (Hazard A below), not by any Konnected/gdolib
+# code change. This opener is a Security+ 1.0 unit, which is exactly the type
+# susceptible to that glitch. The reboot_timeout=0s settings mitigate the reboot
+# loop that exposed it, but a single unexpected reset can still trigger the
+# glitch on a Sec+ 1.0 opener, so the residual risk is not zero. We are keeping
+# the controller off and plan to replace the opener with a newer Security+ unit
+# that is not susceptible to this reboot glitch; this config will be re-enabled
+# against that new opener. The upstream YAML is now back on latest (no commit
+# pin). See:
+#   - https://github.com/ptr727/ESPHome-Config/issues/29           (incident report)
 #   - https://github.com/konnected-io/konnected-esphome/issues/112 (filed upstream)
 #   - https://github.com/konnected-io/konnected-esphome/issues/93  (similar pattern, older)
-#   - templates/konnected-blaq.yaml (pin comment)
 #
-# Initial theories, with corrections from Konnected maintainer
-# (heythisisnate, konnected-io/konnected-esphome#112):
+# Confirmed cause:
 #
-#   Hazard A — Boot-window GPIO1 UART glitch
-#     Theory: GPIO1 (Sec+ UART TX) is uncontrolled between esp_restart() and
-#     secplus_gdo::setup(); a stray pulse could be decoded as a wall-button
-#     press.
-#     Maintainer correction: this mechanism only triggers on Security+ 1.0
-#     openers (those latch on momentary low pulses). This is a Sec+ 2.0
-#     opener (LiftMaster 8500, yellow learn button), which does NOT trigger
-#     on a momentary pull to low or contact closure. So this theory does
-#     not explain either incident on this device.
+#   Hazard A: Boot-window GPIO1 UART glitch  (THIS IS THE CAUSE)
+#     GPIO1 (Sec+ UART TX) is uncontrolled between esp_restart() and
+#     secplus_gdo::setup(); a stray pulse on that line is decoded as a
+#     wall-button press. Per the Konnected maintainer (heythisisnate,
+#     konnected-io/konnected-esphome#112), this mechanism triggers on
+#     Security+ 1.0 openers, which latch on momentary low pulses. This
+#     device IS a Sec+ 1.0 opener, so the glitch fully explains both
+#     incidents: each spurious opening correlated with a reboot/OTA, and
+#     the 15-min reboot loop gave the boot window ~96 chances/day to fire
+#     whenever HA was unreachable.
 #
-#   Hazard B — gdolib v1.1.0 gdo_door_move_to_target() rewrite
-#     Theory: the new routing through gdo_door_open/close could send a
-#     direct OPEN/CLOSE on the Sec+ wire.
-#     Maintainer correction: gdolib v1.1.0's only changes are inside
-#     gdo_door_move_to_target. If nothing called that function (e.g. no HA
-#     "set position to X%" command), it cannot have been the cause.
-#     Incident 1 happened while HA was disconnected, so move_to_target
-#     could not have been invoked. Incident 2 happened during/after an OTA
-#     with no manual set-position command. So this theory is also
-#     unconfirmed.
+#   Hazard B: gdolib v1.1.0 gdo_door_move_to_target() rewrite  (RULED OUT)
+#     Earlier theory: the v1.1.0 routing through gdo_door_open/close could
+#     send a direct OPEN/CLOSE on the Sec+ wire. This is now ruled out.
+#     gdolib v1.1.0's only changes are inside gdo_door_move_to_target, which
+#     is reached only via an explicit "set position to X%" command. Incident
+#     1 happened while HA was disconnected (no caller possible) and Incident
+#     2 had no manual set-position command, so the gdolib change was never
+#     in the path. This is why the commit pin has been removed and we now
+#     sync the latest upstream YAML.
 #
-# What we actually know:
-#   - Two spurious openings correlated in time with reboots/OTAs.
-#   - Powering the blaQ off during Incident 2 immediately stopped the
-#     opener's diagnostic flashing and beeping — evidence the controller
-#     was actively driving the Sec+ wire in steady state, not just
-#     glitching once at boot.
-#   - The mechanism for a Sec+ 2.0 opener to be driven this way during
-#     boot/reboot remains unexplained.
-#
-# Mitigations applied here are defense-in-depth and remain reasonable
-# regardless of which theory turns out correct:
-#   - api.reboot_timeout / wifi.reboot_timeout = 0s: stops the 15-min
-#     reboot loop that exposed Incident 1's many reboot cycles to chance.
-#   - Pin upstream YAML to @501c37e (gdolib v1.0.0): reverts the v1.1.0
-#     code path even though it's not confirmed to be the cause.
+# Mitigations applied here:
+#   - api.reboot_timeout / wifi.reboot_timeout = 0s: stops the 15-min reboot
+#     loop that exposed the boot-window UART glitch. This is the actual fix.
 #   - project_name / project_version override in konnected-blaq.yaml:
 #     blocks the ESPHome Update Manager from force-flashing.
 

--- a/templates/apollo-plt-1b.yaml
+++ b/templates/apollo-plt-1b.yaml
@@ -14,8 +14,7 @@ substitutions:
   # Apollo's PLT-1B.yaml expects these for esphome.name / friendly_name
   name: ${device_name}
   friendly_name: ${device_friendly_name}
-  # Remove project versions so ESPHome Update Manager does not auto update
-  # TODO: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
+  # Remove project version
   version: "0.0.0"
   # Default sleep duration and prevent sleep state if not already set in NVS, else HA owns runtime config.
   sleep_duration_hours: "12"

--- a/templates/konnected-blaq.yaml
+++ b/templates/konnected-blaq.yaml
@@ -15,9 +15,6 @@ substitutions:
   friendly_name: ${device_friendly_name}
   # Per-device override; 0s disables reboot loop that can result in sec1+ UART glitch opening the door.
   wifi_reboot_timeout: 15min
-  # Remove project versions so ESPHome Update Manager does not auto update
-  # TODO: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
-  #
   # NOTE: we cannot `!remove` the entire `esphome.project:` block here the
   # way templates/apollo-plt-1b.yaml does. Konnected's upstream packages
   # reference the compile-time macros `ESPHOME_PROJECT_NAME` and
@@ -32,6 +29,7 @@ substitutions:
   # we can't easily patch. Apollo's PLT-1B.yaml references neither macro,
   # which is why a `!remove` is safe there.
   project_name: "ptr727.${device_name}"
+  # Remove project version
   project_version: "0.0.0"
 
 # https://esphome.io/components/esphome
@@ -43,32 +41,7 @@ esphome:
 # https://esphome.io/guides/configuration-types.html#local-packages
 packages:
   # https://github.com/konnected-io/konnected-esphome/blob/master/garage-door-GDOv2-Q.yaml
-  #
-  # PINNED to commit 501c37e (2026-05-07, gdolib v1.0.0). This pin is
-  # defense-in-depth, not a confirmed fix: the root cause of the two
-  # self-opening incidents on 2026-05-13 is NOT established. See the
-  # STATUS block at the top of garage-door-controller.yaml.
-  #
-  # Konnected maintainer's reply at konnected-io/konnected-esphome#112
-  # narrows the field of candidate causes:
-  #   - The "GPIO1 boot-window UART glitch" theory applies only to
-  #     Security+ 1.0 openers. This is a Sec+ 1.0 (LiftMaster 8500,
-  #     square learn button).
-  #   - gdolib v1.1.0's only changes are inside gdo_door_move_to_target;
-  #     it cannot misbehave unless that function is called. Incident 1
-  #     had HA disconnected (no caller possible) and Incident 2 had no
-  #     manual set-position command, so this is unconfirmed too.
-  # Tracking:
-  #   - https://github.com/ptr727/ESPHome-Config/issues/29           (incident report)
-  #   - https://github.com/konnected-io/konnected-esphome/issues/112 (filed upstream)
-  #   - https://github.com/konnected-io/konnected-esphome/issues/93  (similar pattern, older)
-  #   - https://github.com/konnected-io/konnected-esphome/commit/536e2dd
-  #     (the commit that bumped gdolib v1.0.0 -> v1.1.0)
-  # The pin reverts gdolib to v1.0.0 in case the maintainer's audit of the
-  # move_to_target rewrite finds a path that fires without an explicit
-  # caller. Cheap to keep, easy to undo once the upstream investigation
-  # closes.
-  gdov2q: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@501c37e
+  gdov2q: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml
   api: !include api.yaml
   logger: !include logger.yaml
   ota: !include ota.yaml

--- a/templates/smarthome-ceilsense.yaml
+++ b/templates/smarthome-ceilsense.yaml
@@ -36,7 +36,6 @@ esphome:
   # sensor uses the `${project_version}` substitution, not the macro), unlike
   # templates/konnected-blaq.yaml which must keep the block and override the
   # version substitution instead.
-  # TODO: https://github.com/KriVaTri/ESPHome-Update-Manager/issues/20
   project: !remove
   # Replacement for wifi.yaml's boot phase 1 (which we no longer import), minus
   # the BLE bits: start the status-LED loading animation and wait for WiFi. The


### PR DESCRIPTION
Routine promotion of `develop` to `main` (forward merge), bringing the accumulated `develop` work — including this cycle's CI/lint-gate onboarding — to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)