### PR TITLE
Promote: repo-appropriate HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,4 +4,4 @@ ESPHome device configuration, templates, and firmware for the household.
 
 ## Release History
 
-- Adopted the fleet operational (live-config) governance and lint/validation CI baseline (direct-to-develop model, dispatch-only source releases).
+No published releases yet.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,7 @@
-# ProjectTemplate
+# ESPHome-Config
 
-Governance, agent-orchestration, and workflow-audit hub for a fleet of related repositories.
+ESPHome device configuration, templates, and firmware for the household.
 
 ## Release History
 
-- Version 2.0:
-  - Repurposed from a .NET sample-project template into a governance and workflow-audit catalog: the shared fleet rules (`AGENTS.md`, `CODESTYLE.md`, `WORKFLOW.md`), a machine-readable `spec/`, the fleet `registry/`, per-repo audit `reports/`, branch rulesets, and the `AUDIT.md` convergence procedure. Ships no application code; the old sample project and its build pipeline are removed.
-- Version 1.0:
-  - .NET sample-project template with a build and publish pipeline.
+- Adopted the fleet operational (live-config) governance and lint/validation CI baseline (direct-to-develop model, dispatch-only source releases).


### PR DESCRIPTION
Promote the current `develop` snapshot to `main`. Replaces the template-verbatim HISTORY.md (ProjectTemplate / .NET sample, copied in error during onboarding) with a repo-appropriate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)