### PR TITLE
AGENTS: add missing git governance (signing, identity, staging, branching)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ either - fix mistakes with follow-up commits.
 - **Signing.** Every commit on both `develop` and `main` must be
   cryptographically signed (SSH or GPG); branch protection rejects unsigned
   commits. If signing is not configured in the environment, do not commit -
-  surface it and stop at `git add`.
+  stop at `git add` and tell the developer/maintainer that signing is
+  unconfigured so they can set it up; do not proceed with the commit.
 - **Author identity.** Commit as the repository owner's GitHub `noreply`
   identity (the same identity whose key signs) - never a private, personal, or
   invented/bot address. Verify `git config --get user.email` before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,31 @@ before editing ESPHome configs.
 - All ESPHome CLI invocations must run **inside the container** and use
   `/config/<file>.yaml` as the path argument.
 
+## Branching Model
+
+This is an **operational** repo (see the fleet
+[`workflowModel`](https://github.com/ptr727/ProjectTemplate/blob/main/registry/repos.json)):
+configuration is committed **directly to `develop`** with signed commits - there
+is no feature branch, because this tracks the live controller state. A
+`develop -> main` pull request occasionally promotes a known-good snapshot to
+`main`. `develop` takes direct pushes (advisory CI); the promotion PR runs the
+enforced lint check. Both branches are protected; never force-push or delete
+either - fix mistakes with follow-up commits.
+
+## Git and Commit Rules
+
+- **Signing.** Every commit on both `develop` and `main` must be
+  cryptographically signed (SSH or GPG); branch protection rejects unsigned
+  commits. If signing is not configured in the environment, do not commit -
+  surface it and stop at `git add`.
+- **Author identity.** Commit as the repository owner's GitHub `noreply`
+  identity (the same identity whose key signs) - never a private, personal, or
+  invented/bot address. Verify `git config --get user.email` before committing.
+- **Default to staging.** Stage changes with `git add` and leave `git commit`
+  to the developer, unless the current task explicitly authorizes committing.
+- **No history rewrites.** Never force-push or delete `develop` or `main`; fix
+  mistakes with follow-up commits.
+
 ## Required validation before declaring a change "done"
 
 Whenever a device YAML or a template that's included by a device YAML is


### PR DESCRIPTION
## What

A fleet audit found this repo's `AGENTS.md` had **no git governance**: no commit-signing rule, no author-identity rule, no default-to-staging rule, and no branching model. That gap let an agent commit under a fabricated, unsigned identity.

This PR augments `AGENTS.md` with two sections modeled on the sibling **Vantage-Config** governance and adapted to ESPHome-Config:

- **## Branching Model** - operational repo: configuration is committed directly to `develop` with signed commits (no feature branch); an occasional `develop -> main` PR promotes a known-good snapshot and runs the enforced lint check; both branches protected, never force-push/delete.
- **## Git and Commit Rules**
  - Signing: every commit on both branches must be cryptographically signed (SSH or GPG); branch protection rejects unsigned commits; if signing is not configured, do not commit - stop at `git add`.
  - Author identity: commit as the owner's GitHub `noreply` identity (same identity whose key signs), never a private/personal/invented/bot address; verify `git config --get user.email` first.
  - Default to staging: `git add` and leave `git commit` to the developer unless explicitly authorized.
  - No history rewrites: never force-push or delete `develop`/`main`; fix with follow-up commits.

## Placement

Inserted after **## Repo at a glance**, before **## Required validation**, so repo-wide governance sits up front ahead of the task-specific ESPHome sections.

## Notes

- Line endings preserved as LF; text is ASCII-only, US English, no em-dashes.
- Nothing pre-existing was duplicated - the file had none of this governance.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>