### PR TITLE
Scope CI spell-check to README and HISTORY

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Spell check step
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
-          files: '**/*.md'
+          files: |
+            README.md
+            HISTORY.md
           incremental_files_only: false
 
       - name: Lint workflows step


### PR DESCRIPTION
Narrows the CI cspell step in `.github/workflows/test-pull-request.yml` so it checks only `README.md` + `HISTORY.md` instead of all markdown (`**/*.md`).

## Why

Matches the template default in ptr727/ProjectTemplate#302. Spell-checking all markdown in CI forces endlessly padding `cspell.json` with technical terms that appear in device/config docs. The README and HISTORY are the files every repo visitor sees, so those stay gated; broad live spell-checking remains the editor extension's job.

## Scope

- Only the cspell step's `files:` value changed.
- `markdownlint` stays repo-wide (`**/*.md`) - unchanged.
- actionlint run clean locally against the edited workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)