### PR TITLE
Promote: scope CI spell-check to README + HISTORY

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Spell check step
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
-          files: '**/*.md'
+          files: |
+            README.md
+            HISTORY.md
           incremental_files_only: false
 
       - name: Lint workflows step


### PR DESCRIPTION
Promotion of the CI cspell-scope fix from develop to main.

Narrows the CI spell-check from all markdown (`**/*.md`) to README.md + HISTORY.md, matching template PR ptr727/ProjectTemplate#302. main still runs `**/*.md`; this brings it in line. Trial-merged clean locally — promotion touches only the workflow file. markdownlint stays repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)