### PR TITLE
Conformance: repo-config carry, self-audit, merge-bot (operational)

### DIFF
--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -1,0 +1,87 @@
+name: Merge bot pull request action
+
+# Auto-merges in-repo Dependabot PRs: enable on opened/reopened, disable on a maintainer push. Carried from the
+# fleet reference trimmed to the Dependabot jobs - no codegen bot opens PRs against this repo.
+# - Merge method by base: develop = squash, main = merge.
+# - App token, not GITHUB_TOKEN: fires downstream workflows on merge, and grants write on read-only Dependabot PRs.
+# - pull_request_target, not pull_request: jobs hold the App key, so the workflow + action SHAs resolve from the
+#   trusted base, not PR head. Safe because no job checks out PR code (each runs gh pr merge by URL).
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+# Concurrency keys on the PR number, not github.ref (the base branch under pull_request_target, which would
+# serialize every bot PR against it), so each PR queues independently. cancel-in-progress: false so a follow-up
+# synchronize doesn't cancel an in-flight opened run before it enables auto-merge.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  merge-dependabot:
+    name: Merge dependabot pull request job
+    runs-on: ubuntu-latest
+    # Dependabot PRs from this repo (not forks). Only on opened/reopened so the disable job stays sticky.
+    if: >-
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+
+      - name: Generate GitHub App token step
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
+
+      # Auto-merge every tier, semver-major included: the required checks are the gate, not the bump magnitude.
+      - name: Merge pull request step
+        run: |
+          set -euo pipefail
+          case "${{ github.event.pull_request.base.ref }}" in
+            develop) method=--squash ;;
+            main) method=--merge ;;
+            *)
+              echo "::error::Unsupported base branch: ${{ github.event.pull_request.base.ref }}"
+              exit 1
+              ;;
+          esac
+          gh pr merge --auto "$method" "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  disable-auto-merge-on-maintainer-push:
+    name: Disable auto-merge on maintainer push job
+    runs-on: ubuntu-latest
+    # Fires when a maintainer pushes to a bot's branch (synchronize, actor != bot). Disables auto-merge so the
+    # maintainer's commits don't merge with the bot's, and they re-enable it manually. The disable call is idempotent.
+    if: >-
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor != github.event.pull_request.user.login
+    permissions:
+      pull-requests: write
+
+    steps:
+
+      - name: Generate GitHub App token step
+        # App token because a Dependabot PR's GITHUB_TOKEN is read-only regardless of who triggered the event.
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
+
+      - name: Disable auto-merge step
+        run: gh pr merge --disable-auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,81 @@
+# AUDIT.md
+
+How this repository audits itself against its committed baseline and reports drift. This is the repo-scoped adaptation of the fleet-wide AUDIT.md kept at the fleet hub (carried per the [repo-config downstream carry][repo-config-readme]); the hub's fleet-wide audit remains authoritative. The ground truth here is the committed [`repo-config/`][repo-config] payloads and [`spec/secrets.json`][secrets]; the prose authorities are [`AGENTS.md`][agents], [`CODESTYLE.md`][codestyle], and [`WORKFLOW.md`][workflow].
+
+The audit is read-only: it diffs live state against the committed baseline and reports findings; it never applies changes. The verdict vocabulary is [`WORKFLOW.md`][workflow]'s: **operational / not operational**, **N/A**, **defect**, and the applicable/absent rule.
+
+## Scope
+
+This is an operational (live-config) repo: `main` and `develop` rulesets, general repository settings, and secret names. Code-project dimensions (analyzers, publish mechanisms, coverage) are N/A - see [AGENTS.md "Branching Model"][agents-branching-model] for the model this baseline encodes.
+
+## General Settings
+
+Diff the live repository settings against [`repo-config/settings.json`][repo-config-settings]. The two state-dependent settings are not in the file: `has_discussions` follows visibility (public on / private off) and `default_branch` is `main`.
+
+```sh
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+live=$(gh api "repos/$repo" --jq '{has_wiki,has_projects,allow_merge_commit,allow_squash_merge,allow_rebase_merge,allow_auto_merge,allow_update_branch,delete_branch_on_merge}')
+diff <(jq -S . repo-config/settings.json) <(jq -S . <<<"$live") \
+  && echo "settings: in sync" || echo "settings: DRIFT"
+```
+
+## Rulesets
+
+Diff each live ruleset against the committed expected payload with a normalized comparison (sort the order-insensitive `rules[]` and `bypass_actors[]` before diffing so a reordered but equivalent ruleset does not read as drift). This operational carry keeps its `develop` payload at [`repo-config/operational/develop.json`][repo-config-develop].
+
+```sh
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+norm='{name,target,enforcement,bypass_actors,conditions,rules} | .rules|=sort_by(.type) | .bypass_actors|=sort_by(.actor_id)'
+# Paginate so later-page rulesets count: --paginate with --jq '.[]' emits one JSON object per ruleset
+# across all pages; jq -s re-assembles them into the single array the selections below expect.
+rulesets=$(gh api --paginate "repos/$repo/rulesets" --jq '.[]' | jq -s '.')
+for b in develop main; do
+  file="repo-config/$b.json"
+  [ "$b" = "develop" ] && file="repo-config/operational/develop.json"
+  # Exactly one ruleset per name: zero or duplicates is itself a finding - report it, never diff a guess.
+  count=$(jq --arg n "$b" '[.[] | select(.name==$n)] | length' <<<"$rulesets")
+  [ "$count" -eq 1 ] || { echo "$b: expected exactly 1 ruleset, found $count (defect/drift)"; continue; }
+  id=$(jq --arg n "$b" '.[] | select(.name==$n) | .id' <<<"$rulesets")
+  diff <(jq -S "$norm" "$file") \
+       <(gh api "repos/$repo/rulesets/$id" --jq '{name,target,enforcement,bypass_actors,conditions,rules}' | jq -S "$norm") \
+    && echo "$b: in sync" || echo "$b: DRIFT"
+done
+```
+
+The result must be exactly two rulesets named `develop` and `main` - a missing ruleset or a divergent payload is a **defect**; a duplicate or stray ruleset is a **drift finding**.
+
+## Secrets
+
+Confirm each name [`spec/secrets.json`][secrets] requires exists in the stores its mechanism claims - the name lists derive from the spec itself, so this check and the spec cannot drift apart - and no forbidden name is present in any store (names only; values are not readable).
+
+```sh
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+# Name lists derive from spec/secrets.json (baseline plus any mechanisms, per store claim; forbidden names
+# checked in every store), so this check and the spec cannot drift apart. --paginate so names beyond the
+# first page still count.
+for store in actions dependabot; do
+  names=$(gh api --paginate "repos/$repo/$store/secrets" --jq '.secrets[].name')
+  for s in $(jq -r --arg store "$store" '[.baseline, ((.mechanisms // {}) | .[])] | map(select(.stores | index($store)) | .requires[]) | .[]' spec/secrets.json); do
+    grep -qx "$s" <<<"$names" && echo "$store/$s: present" || echo "$store/$s: MISSING (defect)"
+  done
+  for s in $(jq -r '[.baseline, ((.mechanisms // {}) | .[])] | map(.forbids[]) | .[]' spec/secrets.json); do
+    grep -qx "$s" <<<"$names" && echo "$store/$s: forbidden name present (defect)" || true
+  done
+done
+```
+
+## Verdict and Follow-Up
+
+A missing required item or a divergent payload is a **defect** (not operational); an equivalent outcome in a non-standard form is a **drift finding**. N/A items are excluded, never counted as failures. Surface findings as repository issues; fixes land as direct signed commits to `develop` per [AGENTS.md "Branching Model"][agents-branching-model]. To re-apply the whole baseline, run `repo-config/configure.sh` (see [repo-config/README.md][repo-config-readme]).
+
+<!-- Repo -->
+
+[agents]: ./AGENTS.md
+[agents-branching-model]: ./AGENTS.md#branching-model
+[codestyle]: ./CODESTYLE.md
+[repo-config]: ./repo-config/
+[repo-config-develop]: ./repo-config/operational/develop.json
+[repo-config-readme]: ./repo-config/README.md
+[repo-config-settings]: ./repo-config/settings.json
+[secrets]: ./spec/secrets.json
+[workflow]: ./WORKFLOW.md

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # ESPHome-Config
 
-ESPHome device configuration, templates, and firmware for the household.
+ESPHome configuration templates and projects.
 
 ## Release History
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome-Config
 
-[ESPHome](https://esphome.io) configuration, templates, and home automation projects.
+ESPHome configuration templates and projects.
 
 ## About
 

--- a/repo-config/README.md
+++ b/repo-config/README.md
@@ -1,0 +1,65 @@
+# repo-config
+
+Repository and branch configuration held as committed files, kept out of `.github/` (which holds the GitHub-consumed configuration - workflows, Dependabot). This mirrors the layout the fleet repos use.
+
+- `main.json` plus one `develop` variant - the branch rulesets as the writable API subset (`name`, `target`, `enforcement`, `bypass_actors`, `conditions`, `rules`). The `develop` payload is `develop.json` (`release` repos) or `operational/develop.json` (`operational` repos); this repo is operational, so it carries `operational/develop.json`. These are the canonical expected payloads that the audit (`AUDIT.md`) diffs the live rulesets against.
+- `operational/develop.json` - the `develop` ruleset for **operational** repos (registry `workflowModel: operational`): direct signed pushes, no PR gate. Present at the hub and in operational carries only - a carried `release` repo does not have it. See "Rulesets" below.
+- `configure.sh` - applies the rulesets to a repository via the GitHub API (create or full-payload update, idempotent). Run `repo-config/configure.sh [owner/repo] [release|operational]`; the model may also be passed as the sole argument (`repo-config/configure.sh operational`). With no registry present it infers the model from which `develop` payload is carried (here, `operational`), and an ambiguous layout (both or neither payload) aborts rather than guesses.
+
+## Rulesets
+
+Two workflow models share `main.json` but differ on `develop` (registry `workflowModel`, default `release`):
+
+- **`release`** (`develop.json`): `develop` requires squash merges with linear history and a PR - the feature-branch pipeline.
+- **`operational`** (`operational/develop.json`): `develop` takes **direct signed pushes** - only `deletion`, `non_fast_forward`, and `required_signatures`; no PR, no status-check, no Copilot-on-push. CI runs on the push as advisory feedback. This is for live-service config repos that edit `develop` directly and promote a known-good snapshot to `main` via an occasional PR (see [AGENTS.md "Branching Model"][agents-branching-model]).
+
+`main` (both models) requires merge-commit merges (no linear-history rule), signed commits, a passing `Check pull request workflow status job`, resolved review threads, and Copilot review, and blocks force-pushes and deletion - so a `develop -> main` promotion is always gated even when `develop` takes direct commits. Every ruleset intentionally leaves "Require branches to be up to date before merging" **off** - see [AGENTS.md "Branching Model"][agents-branching-model].
+
+**Configure by importing these JSON files, never by hand-building the rules** (hand reconstruction has gone wrong on past setups). The result must be **exactly two rulesets named `develop` and `main`** - the names are load-bearing (`AGENTS.md` and the workflows reference them); only the `develop` *content* varies by model. First remove all legacy classic branch-protection rules and any stray rulesets, then run `configure.sh` (which picks the `develop` payload from the repo's `workflowModel`), or `gh api -X POST repos/<owner>/<repo>/rulesets --input repo-config/<name>.json` per file (operational repos use `operational/develop.json` for `develop`). `gh ruleset` is read-only; creation goes through `gh api`. The required check binds by name and only turns green after the repo's PR workflow runs once. To edit a ruleset, GET it, change the field, and PUT the whole writable subset back (a partial PUT `422`s).
+
+To change the canonical rulesets, edit the live rulesets (fleet-wide changes happen at the hub), then regenerate the committed files from the current repo:
+
+```sh
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+# Paginate so a name match on a later page is never missed - the same trap configure.sh guards against.
+# --paginate with --jq '.[]' emits one JSON object per ruleset across all pages; jq -s re-assembles them
+# into the single array the selections below expect.
+rulesets=$(gh api --paginate "repos/$repo/rulesets" --jq '.[]' | jq -s '.')
+for name in develop main; do
+  out="repo-config/$name.json"
+  # An operational carry keeps its develop payload at operational/develop.json (develop.json is absent).
+  [ "$name" = "develop" ] && [ ! -f "$out" ] && out="repo-config/operational/develop.json"
+  # Exactly one ruleset per name: zero or duplicates is declared drift - fail loudly, never regen from a guess.
+  count=$(jq --arg n "$name" '[.[] | select(.name==$n)] | length' <<<"$rulesets")
+  [ "$count" -eq 1 ] || { echo "expected exactly 1 ruleset named $name, found $count (drift)" >&2; exit 1; }
+  id=$(jq --arg n "$name" '.[] | select(.name==$n) | .id' <<<"$rulesets")
+  gh api "repos/$repo/rulesets/$id" \
+    --jq '{name, target, enforcement, bypass_actors, conditions, rules}' \
+    | jq -S --indent 4 '.' > "$out"
+done
+```
+
+## Secrets
+
+Publish credentials required per mechanism are enumerated in `spec/secrets.json`. A repo needs only the mechanisms its own publish targets use - a source-only repo needs none of the publish credentials below. NuGet and PyPI use keyless OIDC Trusted Publishing (no stored key; the publish job needs `id-token: write`, and PyPI additionally an `environment: pypi` gate). Docker Hub has no OIDC equivalent and uses a stored `DOCKER_HUB_USERNAME` + `DOCKER_HUB_ACCESS_TOKEN` in both the Actions and Dependabot secret stores. Codegen and merge-bot repos add a GitHub App (`CODEGEN_APP_CLIENT_ID` + `CODEGEN_APP_PRIVATE_KEY` in both stores; the app must be installed, not just created). App-token call sites use `client-id`, never the deprecated `app-id`.
+
+## Repo Settings
+
+The fleet-standard general settings live in [`settings.json`][settings-json] and are applied idempotently by `configure.sh` alongside the rulesets (`gh api PATCH /repos/{owner}/{repo}`). The two settings that depend on per-repo state - `has_discussions` (visibility) and `default_branch` (main-must-exist) - are computed by the script, not stored in the file.
+
+- **Default branch `main`** (the script sets it only when a `main` branch exists, never pointing the default at a missing branch).
+- **Merge methods**: `Allow merge commits` and `Allow squash merging` on, **rebase off** - each branch ruleset then picks its method (merge on `main`, squash on `develop`).
+- **Auto-merge on** (the merge-bot needs it) and **`Always suggest updating pull request branches` on**.
+- **`Automatically delete head branches` OFF - deliberately.** With it on, a `develop -> main` promotion (whose PR head is `develop`) would delete `develop`. There is no per-branch exemption, so the repo-wide toggle stays off to protect `develop`. **The CLI has the same trap: never `gh pr merge --delete-branch` a promotion PR whose head is `develop`** - the explicit flag deletes `develop` regardless of this setting (see [AGENTS.md "Branching Model"][agents-branching-model]).
+- **Wikis and Projects off. Discussions on public repos only** (off on private). **Sponsorships off** - the button is driven by `.github/FUNDING.yml`, not a REST toggle, and the fleet ships none.
+- **Actions / General**: allow GitHub Actions to create and approve pull requests (for the bots).
+
+## Brownfield Migration (Maintainer Only)
+
+`Require signed commits` rejects any pre-existing unsigned commit, so the first `develop -> main` release on a repo with unsigned history is blocked. Re-signing that history is a non-fast-forward that the `Block force pushes` rule rejects, **and the admin bypass does not cover `git push --force`**. Completing it requires temporarily disabling the ruleset and a maintainer force-push. This is a one-time, maintainer-performed migration that deliberately uses the force-push [AGENTS.md "Git and Commit Rules"][agents-git-and-commit-rules] forbids agents from running - **an agent must never execute it; surface it to the maintainer**. Greenfield repos where signing is live before the first commit never hit this.
+
+<!-- Repo -->
+
+[agents-branching-model]: ../AGENTS.md#branching-model
+[agents-git-and-commit-rules]: ../AGENTS.md#git-and-commit-rules
+[settings-json]: ./settings.json

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Apply the committed fleet configuration in this directory to the repository via the GitHub API:
+#   1. General repository settings from settings.json (PATCH /repos/{owner}/{repo}), plus the two settings that depend on
+#      per-repo state - has_discussions (public repos only) and default_branch (main, only if it exists).
+#   2. The branch rulesets. main.json is shared by both workflow models; the develop ruleset is model-specific -
+#      release repos use develop.json (PR-gated), operational repos use operational/develop.json (direct signed
+#      pushes). The model is read from ../registry/repos.json (per-repo workflowModel, else defaults.workflowModel,
+#      else release) and can be overridden with the model argument. In a downstream carry the registry is absent;
+#      the model is then inferred from which develop payload is carried (a carry holds exactly its own model's).
+#      Each <name>.json holds the writable ruleset subset {name, target, enforcement, bypass_actors, conditions,
+#      rules}. An existing ruleset (matched by name) is updated with a full-payload PUT (partial PUTs 422); a
+#      missing one is created with POST.
+# Rerunning is idempotent.
+#
+# Usage: repo-config/configure.sh [owner/repo] [release|operational]   (repo defaults to the current repo via gh;
+#        model defaults to the registry lookup, else payload inference). The model may also be passed as the sole
+#        argument: repo-config/configure.sh operational
+set -euo pipefail
+
+repo_arg="${1:-}"
+model="${2:-}"
+# Allow the model as the sole argument (`repo-config/configure.sh operational`): a model name in arg 1 is not a repo.
+case "$repo_arg" in
+    release|operational) model="$repo_arg"; repo_arg="" ;;
+esac
+repo="${repo_arg:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ----- Resolve the workflow model (selects the develop ruleset) -----
+registry="$script_dir/../registry/repos.json"
+name="${repo##*/}"
+if [ -z "$model" ]; then
+    if [ -f "$registry" ]; then
+        # Fail fast on a jq/parse error (malformed registry) instead of silently applying the release default
+        # to a repo whose lookup actually broke. A repo simply absent from the registry is not an error: the
+        # expression falls back through defaults.workflowModel to "release", so jq still exits 0 with a value.
+        if ! model="$(jq -r --arg n "$name" '(.repos[] | select(.name==$n) | .workflowModel) // .defaults.workflowModel // "release"' "$registry")"; then
+            echo "Failed to read workflowModel from $registry (invalid JSON?). Pass the model explicitly (release|operational)." >&2
+            exit 1
+        fi
+    else
+        # No registry to consult (a downstream carry): infer the model from which develop payload is carried -
+        # a carry holds exactly its own model's payload. Ambiguous layouts (both or neither, e.g. a partial
+        # copy) abort rather than guess; a wrong guess would apply the wrong develop ruleset.
+        if [ -f "$script_dir/develop.json" ] && [ ! -f "$script_dir/operational/develop.json" ]; then
+            model="release"
+        elif [ -f "$script_dir/operational/develop.json" ] && [ ! -f "$script_dir/develop.json" ]; then
+            model="operational"
+        else
+            echo "Registry $registry not found and the carried develop payloads are ambiguous (expected exactly one of develop.json or operational/develop.json). Pass the model explicitly (release|operational)." >&2
+            exit 1
+        fi
+        echo "Registry $registry not found; inferred workflow model '$model' from the carried develop payload." >&2
+    fi
+fi
+case "$model" in
+    release) develop_ruleset="$script_dir/develop.json" ;;
+    operational) develop_ruleset="$script_dir/operational/develop.json" ;;
+    *) echo "Unknown workflow model '$model' (expected release or operational)." >&2; exit 1 ;;
+esac
+echo "Workflow model for $repo: $model"
+
+# ----- General repository settings -----
+settings_file="$script_dir/settings.json"
+if [ -e "$settings_file" ]; then
+    # has_discussions: enabled on public repos only (fleet policy); never on private.
+    private="$(gh api "repos/$repo" --jq '.private')"
+    disc=false; [ "$private" = "false" ] && disc=true
+    # default_branch main, but only point it at main when main exists - never set the default to a missing
+    # branch (e.g. a repo still on a rework branch).
+    if gh api "repos/$repo/branches/main" --jq '.name' >/dev/null 2>&1; then
+        payload="$(jq --argjson d "$disc" '. + {has_discussions: $d, default_branch: "main"}' "$settings_file")"
+    else
+        payload="$(jq --argjson d "$disc" '. + {has_discussions: $d}' "$settings_file")"
+        echo "Warning: $repo has no 'main' branch; leaving default_branch unchanged." >&2
+    fi
+    echo "Applying general settings to $repo (has_discussions=$disc)"
+    printf '%s' "$payload" | gh api --method PATCH "repos/$repo" --input - >/dev/null
+fi
+
+# ----- Branch rulesets -----
+# main.json is shared; the develop ruleset was selected by workflow model above. A missing or nameless
+# payload aborts - silently skipping it would report success on a partially-applied configuration.
+for file in "$develop_ruleset" "$script_dir/main.json"; do
+    if [ ! -e "$file" ]; then
+        echo "Ruleset payload $file not found; aborting to avoid a partially-applied configuration." >&2
+        exit 1
+    fi
+    ruleset_name="$(jq -r '.name // empty' "$file")"
+    if [ -z "$ruleset_name" ]; then
+        echo "Ruleset payload $file has no name; aborting to avoid a partially-applied configuration." >&2
+        exit 1
+    fi
+    # Paginate so a name match on a later page is never missed (which would create a duplicate ruleset), and
+    # fail loudly if the API call itself fails (auth/404/network) rather than treating it as "not found".
+    if ! ids="$(gh api --paginate "repos/$repo/rulesets" --jq ".[] | select(.name==\"$ruleset_name\") | .id")"; then
+        echo "Failed to list rulesets for $repo (check auth and repo access)." >&2
+        exit 1
+    fi
+    # Pre-existing drift can leave more than one ruleset with the same name; update the first and warn. Guard
+    # on non-empty so `grep -c` (which exits non-zero on empty input under `set -e`) can't abort the create path.
+    id=""
+    if [ -n "$ids" ]; then
+        count="$(printf '%s\n' "$ids" | grep -c .)"
+        if [ "$count" -gt 1 ]; then
+            echo "Warning: $count rulesets named '$ruleset_name' on $repo; updating the first (resolve the duplicates)." >&2
+        fi
+        id="$(printf '%s\n' "$ids" | sed -n '1p')"
+    fi
+    if [ -n "$id" ]; then
+        echo "Updating ruleset '$ruleset_name' (id $id) on $repo"
+        gh api --method PUT "repos/$repo/rulesets/$id" --input "$file" >/dev/null
+    else
+        echo "Creating ruleset '$ruleset_name' on $repo"
+        gh api --method POST "repos/$repo/rulesets" --input "$file" >/dev/null
+    fi
+done
+
+echo "Configuration applied to $repo"

--- a/repo-config/main.json
+++ b/repo-config/main.json
@@ -1,0 +1,65 @@
+{
+    "bypass_actors": [
+        {
+            "actor_id": 5,
+            "actor_type": "RepositoryRole",
+            "bypass_mode": "always"
+        }
+    ],
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "refs/heads/main"
+            ]
+        }
+    },
+    "enforcement": "active",
+    "name": "main",
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "required_signatures"
+        },
+        {
+            "parameters": {
+                "allowed_merge_methods": [
+                    "merge"
+                ],
+                "dismiss_stale_reviews_on_push": true,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 0,
+                "required_review_thread_resolution": true,
+                "required_reviewers": []
+            },
+            "type": "pull_request"
+        },
+        {
+            "parameters": {
+                "do_not_enforce_on_create": false,
+                "required_status_checks": [
+                    {
+                        "context": "Check pull request workflow status job",
+                        "integration_id": 15368
+                    }
+                ],
+                "strict_required_status_checks_policy": false
+            },
+            "type": "required_status_checks"
+        },
+        {
+            "parameters": {
+                "review_draft_pull_requests": true,
+                "review_on_push": true
+            },
+            "type": "copilot_code_review"
+        }
+    ],
+    "target": "branch"
+}

--- a/repo-config/operational/develop.json
+++ b/repo-config/operational/develop.json
@@ -1,0 +1,31 @@
+{
+    "bypass_actors": [
+        {
+            "actor_id": 5,
+            "actor_type": "RepositoryRole",
+            "bypass_mode": "always"
+        }
+    ],
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "refs/heads/develop"
+            ]
+        }
+    },
+    "enforcement": "active",
+    "name": "develop",
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "required_signatures"
+        }
+    ],
+    "target": "branch"
+}

--- a/repo-config/settings.json
+++ b/repo-config/settings.json
@@ -1,0 +1,10 @@
+{
+  "has_wiki": false,
+  "has_projects": false,
+  "allow_merge_commit": true,
+  "allow_squash_merge": true,
+  "allow_rebase_merge": false,
+  "allow_auto_merge": true,
+  "allow_update_branch": true,
+  "delete_branch_on_merge": false
+}

--- a/spec/secrets.json
+++ b/spec/secrets.json
@@ -1,0 +1,13 @@
+{
+    "note": "Repo-scoped adaptation of the fleet hub's canonical spec/secrets.json, per the repo-config downstream carry. This repo is source-only with a github-release publish target (mechanism none), so only the fleet baseline applies: no publish-mechanism secrets. AUDIT.md cross-checks these names (values are never read).",
+    "baseline": {
+        "requires": ["CODEGEN_APP_CLIENT_ID", "CODEGEN_APP_PRIVATE_KEY"],
+        "forbids": ["CODEGEN_APP_ID"],
+        "workflowNeeds": ["actions/create-github-app-token"],
+        "stores": ["actions", "dependabot"],
+        "note": "The App-token secrets power the App-signed merge-bot (auto-merge that re-triggers downstream workflows), which every fleet repo runs; also consumed by codegen and the upstream-version tracker where present. Used via actions/create-github-app-token with the client-id input (not the deprecated app-id). The CODEGEN_* name is historical, not codegen-specific."
+    },
+    "targetMechanisms": {
+        "github-release": null
+    }
+}


### PR DESCRIPTION
Addresses #46 - the hub conformance standup for this repo (operational variant).

## What this carries (committed files only)

- \`repo-config/\` operational baseline: \`main.json\`, \`operational/develop.json\`, \`settings.json\`, \`configure.sh\`, and a facts-only \`README.md\`.
- Repo-scoped self-audit: \`AUDIT.md\` + \`spec/secrets.json\`.
- \`.github/workflows/merge-bot-pull-request.yml\` - Dependabot-only auto-merge (App token via \`client-id\`, no \`--delete-branch\`).
- Reworded one-line description in the root \`README.md\` and \`HISTORY.md\`.

Live rulesets, general settings, and secret stores were already in sync per the hub audit, so this is a committed-files-only carry - \`configure.sh\` is not run against the repo.

## Facts-only README adaptation

ESPHome-Config is the first public repo to carry \`repo-config/README.md\`. The fleet "Downstream Carry" process section (and its link to the private Vantage-Config repo, which 404s for the public) is dropped; the carried README states current facts about this repo's config only. A matching upstream finding will be filed against ProjectTemplate.

## Verification

- JSON valid; LF endings; ASCII-only; final newlines; no trailing whitespace.
- Self-audit dry run (settings + both rulesets) reported in sync; secret names present now that the App pair is set.
- Advisory lint CI runs on this PR.

The merge-bot activates now that \`CODEGEN_APP_CLIENT_ID\` + \`CODEGEN_APP_PRIVATE_KEY\` are set in both stores.