### PR TITLE
Promote develop to main: track github-actions Dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,16 @@ updates:
       patterns:
         - "*"
 
+- package-ecosystem: "github-actions"
+  target-branch: "main"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  groups:
+    actions-deps:
+      patterns:
+        - "*"
+
 # develop
 - package-ecosystem: "devcontainers"
   target-branch: "develop"
@@ -23,5 +33,15 @@ updates:
     interval: "weekly"
   groups:
     devcon-deps:
+      patterns:
+        - "*"
+
+- package-ecosystem: "github-actions"
+  target-branch: "develop"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  groups:
+    actions-deps:
       patterns:
         - "*"


### PR DESCRIPTION
Promotes the github-actions Dependabot ecosystem change (#49) to main so Dependabot (which reads its config from the default branch) actually starts tracking the SHA-pinned actions.

- Adds dual-target `github-actions` entries (main + develop, daily, grouped `actions-deps`) alongside the existing `devcontainers` entries.
- Addresses #49.

Merged with a merge commit (never --delete-branch on a develop-headed promotion).