### PR TITLE
Remove per-device sleep overrides from plant sensors

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Setup .NET SDK step
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 10.x
 
@@ -64,7 +64,7 @@ jobs:
       # the tag plus GitHub's auto source archive, README, and LICENSE - no build assets (source-only).
       - name: Create GitHub release step
         if: ${{ steps.release-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch' }}
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
           tag_name: ${{ steps.nbgv.outputs.SemVer2 }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,29 @@ either - fix mistakes with follow-up commits.
   to the developer, unless the current task explicitly authorizes committing.
 - **No history rewrites.** Never force-push or delete `develop` or `main`; fix
   mistakes with follow-up commits.
+- **ESPHome Device Builder auto-commits (disabled - keep it that way).** This
+  directory is the `/config` mount of the running `esphome` container. Device
+  Builder's version history feature polls the tree for changes
+  (`controllers/_device_scanner.py`, stat-based on `(inode, dev, mtime, size)`,
+  not inotify) and commits every changed YAML as `Edit <file>.yaml`, authored
+  `ESPHome Device Builder <device-builder@esphome.io>` and unsigned. It shells
+  out to `git -c user.email=... -c commit.gpgsign=false commit --no-verify`, and
+  command-line `-c` outranks the host gitconfig, so neither the host signing
+  policy nor a hook can stop it. It hit this repo twice: 2026-07-14 (amended
+  away) and 2026-07-18 (five commits, reset and re-committed as `08678ad`).
+  - Turned off via "Save version history" in the Device Builder UI. Persisted in
+    `.device-builder-preferences.json` as `version_history_enabled: false`. That
+    store is RAM-canonical with a debounced write plus a shutdown flush, so
+    patch the file only while the container is stopped; otherwise use the
+    `config/set_preferences` API, which applies live.
+  - If it is ever re-enabled, a clean `git status` no longer proves nothing was
+    committed. After editing files here, run
+    `git log --format='%h %G? %an <%ae>' origin/develop..HEAD` and confirm every
+    commit is signed (`G`) and authored `ptr727@users.noreply.github.com`.
+  - Never push commits failing that check, and never attribute them to yourself
+    or to the maintainer. Check `%an`/`%ae` before claiming or denying
+    authorship. Such commits are unpushed, so correcting them locally is not a
+    history rewrite.
 
 ## Required validation before declaring a change "done"
 

--- a/living-room-plant-sensor.yaml
+++ b/living-room-plant-sensor.yaml
@@ -2,8 +2,6 @@
 substitutions:
   device_name: living-room-plant-sensor
   device_friendly_name: "Living Room Plant Sensor"
-  sleep_duration_hours: "1"
-  prevent_sleep_default: "ON"
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:

--- a/music-room-plant-sensor.yaml
+++ b/music-room-plant-sensor.yaml
@@ -2,8 +2,6 @@
 substitutions:
   device_name: music-room-plant-sensor
   device_friendly_name: "Music Room Plant Sensor"
-  sleep_duration_hours: "1"
-  prevent_sleep_default: "ON"
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:

--- a/patio-plant-sensor.yaml
+++ b/patio-plant-sensor.yaml
@@ -2,8 +2,6 @@
 substitutions:
   device_name: patio-plant-sensor
   device_friendly_name: "Patio Plant Sensor"
-  sleep_duration_hours: "1"
-  prevent_sleep_default: "ON"
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:

--- a/stairs-plant-sensor.yaml
+++ b/stairs-plant-sensor.yaml
@@ -2,8 +2,6 @@
 substitutions:
   device_name: stairs-plant-sensor
   device_friendly_name: "Stairs Plant Sensor"
-  sleep_duration_hours: "1"
-  prevent_sleep_default: "ON"
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:

--- a/upstairs-hallway-plant-sensor.yaml
+++ b/upstairs-hallway-plant-sensor.yaml
@@ -2,8 +2,6 @@
 substitutions:
   device_name: upstairs-hallway-plant-sensor
   device_friendly_name: "Upstairs Hallway Plant Sensor"
-  sleep_duration_hours: "1"
-  prevent_sleep_default: "ON"
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:


### PR DESCRIPTION
Promotes the current `develop` snapshot to `main`.

## Change

Drops `sleep_duration_hours` and `prevent_sleep_default` from the five plant
sensor configs (living room, music room, patio, stairs, upstairs hallway) so
they inherit the `templates/apollo-plt-1b.yaml` defaults (12h sleep, prevent
sleep ON) rather than pinning 1h per device.

The 1h value was set for integration and initial testing. It costs under a
month of 18650 runtime, and the PLT-1B cannot charge over USB (cells have to
be removed and charged externally), so the fleet moves to the template default.

## NVS semantics

Both substitutions are first-boot seeds only. Already-deployed units keep their
NVS values, so the runtime change is applied in Home Assistant via the
Sleep Duration number, not by this commit.

## Validation

`esphome config` passes for all five devices, and the defaults resolve through
the template as expected:

- `initial_value: 12.0` on `deep_sleep_sleep_duration`
- `restore_mode: RESTORE_DEFAULT_ON` on `prevent_sleep`