### PR TITLE
Compile-test every published template in CI

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,13 +1,13 @@
 name: Test pull request action
 
-# Source lint plus a change-gated compile test for the one piece of first-party code in the repo.
-# Everything else is YAML over upstream ESPHome components (tested upstream); the easystart external
-# component is C++ + codegen that can only be caught at compile time, so it is compiled on the same
-# ptr727/esphome-nonroot image the repo deploys. The compile test costs several minutes of esp-idf
-# build, so it runs only when the component or its test config moves.
-# Operational model - develop takes direct signed commits (push runs advisory CI), main is the promoted
-# snapshot (the develop -> main promotion PR runs the enforced gate). check-workflow-status is the
-# ruleset-bound required check - rename it and the branch ruleset context together.
+# Source lint plus change-gated compile tests, run on the ptr727/esphome-nonroot image the repo deploys.
+# - compile-test builds the easystart external component, whose C++ and codegen only fail at compile time.
+# - template-compile-test builds one example device per published template, so nothing ships that cannot build.
+# Both cost minutes of esp-idf build, so each runs only when what it covers moves.
+# Operational model.
+# - develop takes direct signed commits, where push runs advisory CI.
+# - main is the promoted snapshot, where the develop -> main promotion PR runs the enforced gate.
+# - check-workflow-status is the ruleset-bound required check, rename it and the ruleset context together.
 
 on:
   push:
@@ -22,8 +22,9 @@ concurrency:
 
 jobs:
 
-  # Source lint with the same configs the editor extensions and CLI use (linter parity): markdown, spelling, and
-  # workflow YAML run as pinned action wrappers; editorconfig-checker's action is install-only, so it runs via Docker.
+  # Source lint with the same configs the editor extensions and CLI use, for linter parity.
+  # Markdown, spelling, and workflow YAML run as pinned action wrappers.
+  # editorconfig-checker's action is install-only, so it runs via Docker.
   lint:
     name: Lint sources job
     runs-on: ubuntu-latest
@@ -57,8 +58,9 @@ jobs:
       - name: Setup uv step
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
-      # Lint the standalone Python utility (easystart BLE monitor) with ruff, matching the ptr727
-      # fleet convention (uvx, pinned tool version; pyright stays editor-only via Pylance).
+      # Lint the standalone Python utility, the easystart BLE monitor, with ruff.
+      # Matches the ptr727 fleet convention of uvx with a pinned tool version.
+      # pyright stays editor-only via Pylance.
       - name: Lint Python step
         working-directory: easystart/python
         run: |
@@ -66,15 +68,18 @@ jobs:
           uvx ruff@0.15.22 check .
           uvx ruff@0.15.22 format --check .
 
-  # Change gate for the compile test: a full esp-idf build costs several minutes, so run it only when the
-  # easystart component, its CI test config, or this workflow changes. Anything undeterminable defaults to running.
+  # Change gate for the compile tests, plus the template matrix definition.
+  # An esp-idf build costs minutes, so gate on what each test covers.
+  # An undeterminable diff runs everything.
   changes:
-    name: Detect easystart changes job
+    name: Detect build-affecting changes job
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       compile-test: ${{ steps.filter.outputs.compile-test }}
+      template-test: ${{ steps.filter.outputs.template-test }}
+      template-configs: ${{ steps.configs.outputs.template-configs }}
 
     steps:
 
@@ -92,27 +97,58 @@ jobs:
           AFTER: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # No diff to reason about (manual run) - compile-test rather than guess.
-          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+          run_all() {
             echo "compile-test=true" >> "$GITHUB_OUTPUT"
+            echo "template-test=true" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
+          }
+          # A manual run has no diff, and is also how a full rebuild sweep is requested.
+          [[ "$EVENT" == "workflow_dispatch" ]] && run_all
           FROM="$BEFORE"
           [[ "$EVENT" == "pull_request" ]] && FROM="$BASE_SHA"
-          # A new branch (all-zeros before) or an unreachable base - compile-test everything.
+          # A new branch (all-zeros before) or an unreachable base - build everything.
           if [[ -z "$FROM" || "$FROM" =~ ^0+$ ]] || ! DIFF=$(git diff --name-only "$FROM" "$AFTER" 2>/dev/null); then
-            echo "compile-test=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            run_all
           fi
-          if grep -qE '^(easystart/components/|easystart/test/|\.github/workflows/test-pull-request\.yml$)' <<<"$DIFF"; then
+          WORKFLOW='\.github/workflows/test-pull-request\.yml$'
+          if grep -qE "^(easystart/components/|easystart/test/|$WORKFLOW)" <<<"$DIFF"; then
             echo "compile-test=true" >> "$GITHUB_OUTPUT"
           else
             echo "compile-test=false" >> "$GITHUB_OUTPUT"
           fi
+          # test/ hosts the example devices, and test/easystart.yaml compiles easystart/components.
+          if grep -qE "^(templates/|test/|easystart/components/|$WORKFLOW)" <<<"$DIFF"; then
+            echo "template-test=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "template-test=false" >> "$GITHUB_OUTPUT"
+          fi
 
-  # Compile the easystart component in the deployment image (ptr727/esphome-nonroot). The build tree and HOME
-  # live under the world-writable /cache mount that the image's cache.sh initializes; /config is the repo, so the
-  # test config's `path: ../components` resolves to the real component source.
+      # Build the template matrix from test/, so a new example device is picked up without editing the matrix.
+      # Every device template must have an example device, else a new template would go silently untested.
+      # Utility includes are pulled in transitively by the device templates and need no example device.
+      - name: List template test configs step
+        id: configs
+        env:
+          UTILITY: api basic common debug ethernet-sensor logger ota rgb-led-status secrets temperature time wifi
+        run: |
+          set -euo pipefail
+          missing=()
+          for path in templates/*.yaml; do
+            name="$(basename "$path" .yaml)"
+            case " $UTILITY " in *" $name "*) continue;; esac
+            [[ -f "test/$name.yaml" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Templates with no example device in test/: ${missing[*]}"
+            exit 1
+          fi
+          CONFIGS="$(basename -a -s .yaml test/*.yaml | jq -Rsc 'split("\n") | map(select(length > 0))')"
+          echo "Template matrix: $CONFIGS"
+          echo "template-configs=$CONFIGS" >> "$GITHUB_OUTPUT"
+
+  # Compile the easystart component in the deployment image, ptr727/esphome-nonroot.
+  # The build tree and HOME live under the world-writable /cache mount that the image's cache.sh initializes.
+  # /config is the repo, so the test config's `path: ../components` resolves to the real component source.
   compile-test:
     name: Compile test job
     runs-on: ubuntu-latest
@@ -142,12 +178,59 @@ jobs:
               esphome compile /config/easystart/test/compile-test.yaml
             '
 
-  # GitHub Actions does not support required status checks on conditional jobs, so a single always-run aggregator gates
-  # the merge. Its name is the ruleset-bound required status-check context - rename it and the ruleset context together.
+  # Compile one example device per published template.
+  # test/ holds the configs, and the Device Builder scan is non-recursive, so they are not listed as devices.
+  # The matrix comes from the changes job, which also enforces that every template has an example device.
+  # fail-fast is off so one broken template does not mask the others.
+  template-compile-test:
+    name: Compile template ${{ matrix.config }} job
+    runs-on: ubuntu-latest
+    needs: [ changes ]
+    if: ${{ needs.changes.outputs.template-test == 'true' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON(needs.changes.outputs.template-configs) }}
+
+    steps:
+
+      - name: Checkout code step
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Templates resolve !secret via templates/secrets.yaml, which re-exports the root secrets.yaml.
+      # secrets._yaml supplies the key names.
+      # The encryption key is generated here, so no usable key is committed.
+      - name: Create dummy secrets step
+        run: |
+          set -euo pipefail
+          cp secrets._yaml secrets.yaml
+          sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$(openssl rand -base64 32)|" secrets.yaml
+
+      - name: Compile template test config step
+        run: |
+          set -euo pipefail
+          cache="$(mktemp -d)"
+          chmod -R 0777 "$cache" .
+          docker run --rm --user 1000:1000 \
+            --volume "$PWD":/config \
+            --volume "$cache":/cache \
+            ptr727/esphome-nonroot:latest \
+            bash -c '
+              set -euo pipefail
+              /entrypoint/cache.sh
+              esphome config /config/test/${{ matrix.config }}.yaml > /dev/null
+              esphome compile /config/test/${{ matrix.config }}.yaml
+            '
+
+  # GitHub Actions does not support required status checks on conditional jobs.
+  # A single always-run aggregator gates the merge instead.
+  # Its name is the ruleset-bound required status-check context, rename it and the ruleset context together.
   check-workflow-status:
     name: Check pull request workflow status job
     runs-on: ubuntu-latest
-    needs: [ lint, changes, compile-test ]
+    needs: [ lint, changes, compile-test, template-compile-test ]
     if: always()
     steps:
       - name: Check workflow results step
@@ -161,8 +244,14 @@ jobs:
             echo "Job 'changes' did not succeed (${{ needs.changes.result }}); refusing to pass."
             exit 1
           fi
-          # compile-test is skipped when the gate says the component did not change; only a real failure blocks.
+          # The compile jobs are skipped when the change gate says nothing they cover moved.
+          # Only a real failure blocks, a skip must still pass.
+          # The matrix aggregates to a single result, failure if any leg failed.
           if [[ "${{ needs.compile-test.result }}" == "failure" ]]; then
             echo "Job 'compile-test' failed; refusing to pass."
+            exit 1
+          fi
+          if [[ "${{ needs.template-compile-test.result }}" == "failure" ]]; then
+            echo "Job 'template-compile-test' failed; refusing to pass."
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ __pycache__/
 *.pyc
 .ruff_cache/
 
-# ESPHome build artifacts (e.g. from compiling easystart/test/compile-test.yaml locally);
-# ESPHome also auto-writes a boilerplate .gitignore into any config dir it compiles.
+# ESPHome build artifacts, from compiling the test configs locally.
+# ESPHome also auto-writes a boilerplate .gitignore into any config directory it compiles.
 .esphome/
 easystart/test/.gitignore
+test/.gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,32 @@ Write like the developer who owns this repo, not like an AI assistant.
   messages, PR text. If the user adds a Unicode symbol on purpose, leave it; just
   don't author em-dashes or decorative non-ASCII yourself.
 
+### Comments are structured, not prose
+
+Comment only where a comment is needed, and keep it scannable.
+
+- Prefer a single-line comment.
+- One sentence per line; never wrap prose across lines.
+- No block paragraphs and no multi-sentence run-ons.
+- Indent with sub-bullets (`# - point`) only for actual sub-topics, meaning parallel items
+  hanging off a lead line. A continuation of the same topic stays unindented.
+
+Continuation, so no indentation:
+
+```yaml
+# Change gate for the compile tests.
+# An esp-idf build costs minutes, so gate on what each test covers.
+# An undeterminable diff runs everything.
+```
+
+Sub-topics, so indented, because each line elaborates a distinct item named in the lead:
+
+```yaml
+# Source lint plus change-gated compile tests.
+# - compile-test builds the easystart external component.
+# - template-compile-test builds one example device per published template.
+```
+
 ## Reverse-engineering and external tooling
 
 BLE and device reverse-engineering work (for example the Micro-Air EasyStart soft-starter)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A [collection](./templates/) of utility and device-specific configuration templa
 
 Note that for devices with native ESPHome factory firmware, I opt to strip out the generic project and [Improv](https://www.improv-wifi.com/) configuration in favor of a custom configuration specific to my environment. This also cuts down on resource utilization by removing unused features.
 
+Every device template has an example configuration in [test](./test/) that CI compiles against the current ESPHome release, so a published template is known to build. The examples also serve as minimal usage samples.
+
 ### Device Templates
 
 #### Ayococr X5P WiFi Plug

--- a/templates/efun-sh331.yaml
+++ b/templates/efun-sh331.yaml
@@ -1,6 +1,6 @@
 # Required substitutions:
 # device_name
-# device_comment
+# device_friendly_name
 
 # https://community.home-assistant.io/t/efun-sh331w-smart-plug-esphome-configuration-file/161112
 # https://templates.blakadder.com/efun_SH331W.html

--- a/templates/esp32-s3-wroom-2-n32r8v.yaml
+++ b/templates/esp32-s3-wroom-2-n32r8v.yaml
@@ -59,6 +59,11 @@ esp32:
     # "Warning! Flash memory size mismatch detected. Expected 32MB, found 2MB!"
     sdkconfig_options:
       CONFIG_ESPTOOLPY_FLASHSIZE_32MB: "y"
+    # ESPHome rejects 32MB flash with OTA unless experimental IDF features are opted in.
+    # common.yaml always pulls OTA in, so the opt-in is required to build at all.
+    # This does not fix the OTA limitation in the TODO above, 16MB remains the safer choice.
+    advanced:
+      enable_idf_experimental_features: true
 
 # https://esphome.io/components/psram
 psram:

--- a/templates/norvi-enet-ae06-r.yaml
+++ b/templates/norvi-enet-ae06-r.yaml
@@ -170,6 +170,12 @@
 ## https://github.com/esphome/feature-requests/issues/513
 
 
+# ESPHome resolves `includes:` against the device config's directory, not this template's.
+# The default suits a device config in the repository root.
+# An including config elsewhere overrides it, see test/norvi-enet-ae06-r.yaml.
+substitutions:
+  templates_dir: templates
+
 # https://esphome.io/components/esphome
 esphome:
   name: ${device_name}
@@ -181,7 +187,7 @@ esphome:
         - ds1307.read_time:
   includes:
     # Utility functions
-    templates/Utils.h
+    ${templates_dir}/Utils.h
 
 # https://esphome.io/components/esp32
 esp32:

--- a/templates/smarthome-ceilsense.yaml
+++ b/templates/smarthome-ceilsense.yaml
@@ -91,10 +91,12 @@ select:
 button:
   - id: !remove update_firmware
 
-# Remove the glue script that drives the firmware selector/update (references
-# firmware_selector + firmware_update, both removed above).
+# Remove the glue scripts driving the firmware selector/update.
+# Both reference firmware_selector and firmware_update, removed above.
+# Their only caller was the firmware_selector select, also removed.
 script:
   - id: !remove sync_selected_firmware_source
+  - id: !remove check_firmware_update_when_online
 
 # Remove base.yaml's "Disable Bluetooth after boot" switch - it only gated
 # wifi.yaml's now-absent ble.disable call, and we run no Bluetooth at all. The

--- a/templates/sonoff-s31.yaml
+++ b/templates/sonoff-s31.yaml
@@ -30,6 +30,8 @@ logger:
 uart:
   rx_pin: RX
   baud_rate: 4800
+  # The CSE7766 transmits 8E1; ESPHome requires the parity to be declared to match.
+  parity: EVEN
 
 # https://esphome.io/guides/configuration-types.html#packages
 packages:

--- a/test/adafruit-esp32-s3-feather.yaml
+++ b/test/adafruit-esp32-s3-feather.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/adafruit-esp32-s3-feather.yaml
+substitutions:
+  device_name: adafruit-esp32-s3-feather-test
+  device_friendly_name: "Adafruit ESP32-S3 Feather Test"
+
+packages:
+  device: !include ../templates/adafruit-esp32-s3-feather.yaml

--- a/test/aoycocr-x5p.yaml
+++ b/test/aoycocr-x5p.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/aoycocr-x5p.yaml
+substitutions:
+  device_name: aoycocr-x5p-test
+  device_friendly_name: "Aoycocr X5P Test"
+
+packages:
+  device: !include ../templates/aoycocr-x5p.yaml

--- a/test/apollo-plt-1b.yaml
+++ b/test/apollo-plt-1b.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/apollo-plt-1b.yaml
+substitutions:
+  device_name: apollo-plt-1b-test
+  device_friendly_name: "Apollo PLT-1B Test"
+
+packages:
+  device: !include ../templates/apollo-plt-1b.yaml

--- a/test/easystart.yaml
+++ b/test/easystart.yaml
@@ -1,0 +1,28 @@
+# CI compile-test for templates/easystart.yaml
+# The template is a parameterized package, not a standalone device.
+# Hosted on a Bluetooth proxy, as office-bluetooth-proxy.yaml does.
+# Uses a dummy MAC instead of a secret.
+substitutions:
+  device_name: easystart-test
+  device_friendly_name: "EasyStart Test"
+
+packages:
+  gls10: !include ../templates/gls10-bluetooth-proxy.yaml
+  easystart_1: !include
+    file: ../templates/easystart.yaml
+    vars:
+      easystart_id: easystart_1
+      easystart_mac: "AA:BB:CC:DD:EE:01"
+      easystart_label: "Compressor 1"
+
+# https://esphome.io/components/external_components
+external_components:
+  - source:
+      type: local
+      path: ../easystart/components
+    components: [easystart]
+
+# https://esphome.io/components/esp32_ble
+# Must be at least 3 (bluetooth_proxy default connections) plus one per ble_client.
+esp32_ble:
+  max_connections: 4

--- a/test/efun-sh331.yaml
+++ b/test/efun-sh331.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/efun-sh331.yaml
+substitutions:
+  device_name: efun-sh331-test
+  device_friendly_name: "EFUN SH331 Test"
+
+packages:
+  device: !include ../templates/efun-sh331.yaml

--- a/test/esp32-s3-devkitc.yaml
+++ b/test/esp32-s3-devkitc.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/esp32-s3-devkitc.yaml
+substitutions:
+  device_name: esp32-s3-devkitc-test
+  device_friendly_name: "ESP32-S3-DevKitC Test"
+
+packages:
+  device: !include ../templates/esp32-s3-devkitc.yaml

--- a/test/esp32-s3-wroom-2-n16r8v.yaml
+++ b/test/esp32-s3-wroom-2-n16r8v.yaml
@@ -1,0 +1,10 @@
+# CI compile-test for templates/esp32-s3-wroom-2-n16r8v.yaml
+# The board definition is an overlay, not a standalone device.
+# Composed on the devkit template, as esp32-s3-devkitc.yaml documents.
+substitutions:
+  device_name: esp32-s3-wroom2-n16r8v-test
+  device_friendly_name: "ESP32-S3-WROOM-2-N16R8V Test"
+
+packages:
+  device: !include ../templates/esp32-s3-devkitc.yaml
+  board: !include ../templates/esp32-s3-wroom-2-n16r8v.yaml

--- a/test/esp32-s3-wroom-2-n32r8v.yaml
+++ b/test/esp32-s3-wroom-2-n32r8v.yaml
@@ -1,0 +1,10 @@
+# CI compile-test for templates/esp32-s3-wroom-2-n32r8v.yaml
+# The board definition is an overlay, not a standalone device.
+# Composed on the devkit template, as esp32-s3-devkitc.yaml documents.
+substitutions:
+  device_name: esp32-s3-wroom2-n32r8v-test
+  device_friendly_name: "ESP32-S3-WROOM-2-N32R8V Test"
+
+packages:
+  device: !include ../templates/esp32-s3-devkitc.yaml
+  board: !include ../templates/esp32-s3-wroom-2-n32r8v.yaml

--- a/test/gls10-bluetooth-proxy.yaml
+++ b/test/gls10-bluetooth-proxy.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/gls10-bluetooth-proxy.yaml
+substitutions:
+  device_name: gls10-bluetooth-proxy-test
+  device_friendly_name: "GL-S10 Bluetooth Proxy Test"
+
+packages:
+  device: !include ../templates/gls10-bluetooth-proxy.yaml

--- a/test/kincony-kc868-asr.yaml
+++ b/test/kincony-kc868-asr.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/kincony-kc868-asr.yaml
+substitutions:
+  device_name: kincony-kc868-asr-test
+  device_friendly_name: "Kincony KC868-ASR Test"
+
+packages:
+  device: !include ../templates/kincony-kc868-asr.yaml

--- a/test/konnected-blaq.yaml
+++ b/test/konnected-blaq.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/konnected-blaq.yaml
+substitutions:
+  device_name: konnected-blaq-test
+  device_friendly_name: "Konnected blaQ Test"
+
+packages:
+  device: !include ../templates/konnected-blaq.yaml

--- a/test/norvi-enet-ae06-r.yaml
+++ b/test/norvi-enet-ae06-r.yaml
@@ -1,0 +1,10 @@
+# CI compile-test for templates/norvi-enet-ae06-r.yaml
+# The template's `includes:` resolves against this config's directory, not the template's.
+# templates_dir points back at templates/ from here.
+substitutions:
+  device_name: norvi-enet-ae06-r-test
+  device_friendly_name: "Norvi ENET-AE06-R Test"
+  templates_dir: ../templates
+
+packages:
+  device: !include ../templates/norvi-enet-ae06-r.yaml

--- a/test/rocket-astra.yaml
+++ b/test/rocket-astra.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/rocket-astra.yaml
+substitutions:
+  device_name: rocket-astra-test
+  device_friendly_name: "RocketController ASTRA Test"
+
+packages:
+  device: !include ../templates/rocket-astra.yaml

--- a/test/smarthome-ceilsense.yaml
+++ b/test/smarthome-ceilsense.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/smarthome-ceilsense.yaml
+substitutions:
+  device_name: smarthome-ceilsense-test
+  device_friendly_name: "SmartHomeShop CeilSense Test"
+
+packages:
+  device: !include ../templates/smarthome-ceilsense.yaml

--- a/test/sonoff-s31.yaml
+++ b/test/sonoff-s31.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/sonoff-s31.yaml
+substitutions:
+  device_name: sonoff-s31-test
+  device_friendly_name: "Sonoff S31 Test"
+
+packages:
+  device: !include ../templates/sonoff-s31.yaml

--- a/test/sonoff-th10.yaml
+++ b/test/sonoff-th10.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/sonoff-th10.yaml
+substitutions:
+  device_name: sonoff-th10-test
+  device_friendly_name: "Sonoff TH10 Test"
+
+packages:
+  device: !include ../templates/sonoff-th10.yaml

--- a/test/wemos-lolin32-lite.yaml
+++ b/test/wemos-lolin32-lite.yaml
@@ -1,0 +1,7 @@
+# CI compile-test for templates/wemos-lolin32-lite.yaml
+substitutions:
+  device_name: wemos-lolin32-lite-test
+  device_friendly_name: "WEMOS LOLIN32 Lite Test"
+
+packages:
+  device: !include ../templates/wemos-lolin32-lite.yaml


### PR DESCRIPTION
Extends the change-gated compile test, which previously covered only the `easystart` component, to every published template. Anything published is now known to build against the current ESPHome release.

## Changes

- 17 example device configs under `test/`, one per device template. Subdirectories are invisible to the ESPHome Device Builder dashboard, whose scan is non-recursive, so these do not show up as phantom devices.
- A `fail-fast: false` matrix job compiling each config on the `ptr727/esphome-nonroot` deployment image, so every template reports its own pass/fail.
- The matrix is generated from `test/` by the `changes` job, which also fails the run when a template outside the utility-include set has no example device. A newly published template therefore cannot go silently untested.
- Change gate extended to `templates/`, `test/`, and `easystart/components/`; the aggregator fails only on `failure`, so a gated skip still passes.

## Template fixes found by the first sweep

Three published templates did not build:

- `sonoff-s31`: missing `parity: EVEN`, the CSE7766 transmits 8E1.
- `smarthome-ceilsense`: upstream added `check_firmware_update_when_online`, which references entities this template strips.
- `esp32-s3-wroom-2-n32r8v`: 32MB flash with OTA requires the experimental IDF opt-in.

`norvi-enet-ae06-r` gains a `templates_dir` substitution so its `Utils.h` include follows the including config, since ESPHome resolves `includes:` against the device config directory rather than the template directory. `efun-sh331` had a stale `device_comment` in its header.

## Verification

- All 17 test configs and all 12 root device configs validate.
- The four changed templates compiled locally, plus `garage-gate-fan-controller.yaml` as a real-device regression, since `includes:` only resolves at build time.
- actionlint, editorconfig-checker, markdownlint, and cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)