### PR TITLE
Add ESP32-S3-WROOM-1-N16R8 board template and modernize the WROOM-2 pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Shared building-block includes, composed via `packages:` by the device templates
 
 Board and component helpers:
 
-- [RGB LED Status](./templates/rgb-led-status.yaml) component. Useful for boards with only a RGB LED to use as [Status LED](https://esphome.io/components/status_led.html) component equivalent.
+- [RGB LED Status](./templates/rgb-led-status.yaml) component. Useful for boards with only an RGB LED to use as [Status LED](https://esphome.io/components/status_led.html) component equivalent.
 - [ESP32-S3-DevKitC](./templates/esp32-s3-devkitc.yaml) devkit template, and the [ESP32-S3-WROOM-1-N16R8](./templates/esp32-s3-wroom-1-n16r8.yaml), [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml), and [ESP32-S3-WROOM-2-N32R8V](./templates/esp32-s3-wroom-2-n32r8v.yaml) board definitions for the [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html) boards. The default [`esp32-s3-devkitc-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board only supports the `ESP32-S3-WROOM-1-N8` with 8MB Quad Flash and no PSRAM, so compose the devkit template with the board definition matching the fitted module. Includes the on-chip temperature sensor and RGB LED as status LED. Note that the RGB LED moved from GPIO48 to GPIO38 at board revision v1.1, override the `rgb_led_pin` substitution if the LED stays dark.
 - [WEMOS LOLIN32 Lite](./templates/wemos-lolin32-lite.yaml) devkit template for [WEMOS LOLIN32 Lite](https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite) and clone boards. Includes the LED as status LED.
 - [Adafruit ESP32-S3 Feather](./templates/adafruit-esp32-s3-feather.yaml) devkit template for the [Adafruit ESP32-S3 Feather](https://www.adafruit.com/product/5323) board. Includes the on-chip temperature sensor, RGB LED as status LED, and [MAX17048](https://www.analog.com/en/products/max17048.html) I2C battery charge monitor.
@@ -195,7 +195,7 @@ Per-device configs live in the repository root. Each sets `substitutions:` (devi
 - Install Python from the Microsoft Store.
 - Setup [VSCode](#vscode-setup).
 - Compile ESPHome project: `esphome compile test/adafruit-esp32-s3-feather.yaml`.
-- Plugin device, hold Boot and press Reset if required.
+- Plug in the device, hold Boot and press Reset if required.
 - List COM ports from PowerShell:
   - Serial ports: `[System.IO.Ports.SerialPort]::getportnames()`
   - Msft drivers: `Get-CimInstance -Class Win32_SerialPort | Select-Object Name, Description, DeviceID`.

--- a/README.md
+++ b/README.md
@@ -102,12 +102,37 @@ Shared building-block includes, composed via `packages:` by the device templates
 - [`ethernet-sensor.yaml`](./templates/ethernet-sensor.yaml) - Ethernet IP / MAC info text sensors.
 - [`secrets.yaml`](./templates/secrets.yaml) - re-exports the root `secrets.yaml` so templates can resolve secrets.
 
-Board and component helpers:
+### Board and Component Helpers
 
-- [RGB LED Status](./templates/rgb-led-status.yaml) component. Useful for boards with only an RGB LED to use as [Status LED](https://esphome.io/components/status_led.html) component equivalent.
-- [ESP32-S3-DevKitC](./templates/esp32-s3-devkitc.yaml) devkit template, and the [ESP32-S3-WROOM-1-N16R8](./templates/esp32-s3-wroom-1-n16r8.yaml), [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml), and [ESP32-S3-WROOM-2-N32R8V](./templates/esp32-s3-wroom-2-n32r8v.yaml) board definitions for the [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html) boards. The default [`esp32-s3-devkitc-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board only supports the `ESP32-S3-WROOM-1-N8` with 8MB Quad Flash and no PSRAM, so compose the devkit template with the board definition matching the fitted module. Includes the on-chip temperature sensor and RGB LED as status LED. Note that the RGB LED moved from GPIO48 to GPIO38 at board revision v1.1, override the `rgb_led_pin` substitution if the LED stays dark.
-- [WEMOS LOLIN32 Lite](./templates/wemos-lolin32-lite.yaml) devkit template for [WEMOS LOLIN32 Lite](https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite) and clone boards. Includes the LED as status LED.
-- [Adafruit ESP32-S3 Feather](./templates/adafruit-esp32-s3-feather.yaml) devkit template for the [Adafruit ESP32-S3 Feather](https://www.adafruit.com/product/5323) board. Includes the on-chip temperature sensor, RGB LED as status LED, and [MAX17048](https://www.analog.com/en/products/max17048.html) I2C battery charge monitor.
+#### RGB LED Status Component
+
+- [Template](./templates/rgb-led-status.yaml) for boards that have an addressable RGB LED but no plain status LED.
+- Serves as the [Status LED](https://esphome.io/components/status_led.html) component equivalent.
+
+#### Espressif ESP32-S3-DevKitC-1 Devkit
+
+- [Template](./templates/esp32-s3-devkitc.yaml) for the [ESP32-S3-DevKitC-1](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html) and clone boards.
+- Includes the on-chip temperature sensor and the RGB LED as status LED.
+- The default [`esp32-s3-devkitc-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board is the `ESP32-S3-WROOM-1-N8`, 8MB Quad Flash and no PSRAM.
+- Compose the devkit template with the board definition matching the fitted module:
+  - [ESP32-S3-WROOM-1-N16R8](./templates/esp32-s3-wroom-1-n16r8.yaml): 16MB Quad Flash, 8MB Octal PSRAM, 3.3V.
+  - [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml): 16MB Octal Flash, 8MB Octal PSRAM, 1.8V.
+  - [ESP32-S3-WROOM-2-N32R8V](./templates/esp32-s3-wroom-2-n32r8v.yaml): 32MB Octal Flash, 8MB Octal PSRAM, 1.8V.
+- Note:
+  - The RGB LED moved from GPIO48 to GPIO38 at board revision v1.1, override the `rgb_led_pin` substitution if the LED stays dark.
+  - WROOM-1 and WROOM-1U modules differ only in PCB antenna versus IPEX connector, and are identical to program.
+  - See the OTA and Octal flash mode notes in [esp32-s3-wroom-2-n32r8v.yaml](./templates/esp32-s3-wroom-2-n32r8v.yaml) before choosing a 32MB module.
+
+#### WEMOS LOLIN32 Lite Devkit
+
+- [Template](./templates/wemos-lolin32-lite.yaml) for the [WEMOS LOLIN32 Lite](https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite) and clone boards.
+- Includes the LED as status LED.
+
+#### Adafruit ESP32-S3 Feather Devkit
+
+- [Template](./templates/adafruit-esp32-s3-feather.yaml) for the [Adafruit ESP32-S3 Feather](https://www.adafruit.com/product/5323) board.
+- Includes the on-chip temperature sensor and the RGB LED as status LED.
+- Includes the [MAX17048](https://www.analog.com/en/products/max17048.html) I2C battery charge monitor.
 
 ## Projects
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Shared building-block includes, composed via `packages:` by the device templates
 Board and component helpers:
 
 - [RGB LED Status](./templates/rgb-led-status.yaml) component. Useful for boards with only a RGB LED to use as [Status LED](https://esphome.io/components/status_led.html) component equivalent.
-- [ESP32-S3-DevKitC](./templates/esp32-s3-devkitc.yaml) devkit template, and [ESP32-S3-WROOM-2-N32R8V](./templates/esp32-s3-wroom-2-n32r8v.yaml) and [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml) board definitions for the [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html) boards. The default [`esp32-s3-devkit-c-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board only supports the `ESP32-S3-WROOM-1-N8` with 8MB Quad Flash and no PSRAM, any other board requires some customization, especially for the Octal memory boards. Includes the on-chip temperature sensor and RGB LED as status LED.
+- [ESP32-S3-DevKitC](./templates/esp32-s3-devkitc.yaml) devkit template, and the [ESP32-S3-WROOM-1-N16R8](./templates/esp32-s3-wroom-1-n16r8.yaml), [ESP32-S3-WROOM-2-N16R8V](./templates/esp32-s3-wroom-2-n16r8v.yaml), and [ESP32-S3-WROOM-2-N32R8V](./templates/esp32-s3-wroom-2-n32r8v.yaml) board definitions for the [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html) boards. The default [`esp32-s3-devkitc-1`](https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html) board only supports the `ESP32-S3-WROOM-1-N8` with 8MB Quad Flash and no PSRAM, so compose the devkit template with the board definition matching the fitted module. Includes the on-chip temperature sensor and RGB LED as status LED. Note that the RGB LED moved from GPIO48 to GPIO38 at board revision v1.1, override the `rgb_led_pin` substitution if the LED stays dark.
 - [WEMOS LOLIN32 Lite](./templates/wemos-lolin32-lite.yaml) devkit template for [WEMOS LOLIN32 Lite](https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite) and clone boards. Includes the LED as status LED.
 - [Adafruit ESP32-S3 Feather](./templates/adafruit-esp32-s3-feather.yaml) devkit template for the [Adafruit ESP32-S3 Feather](https://www.adafruit.com/product/5323) board. Includes the on-chip temperature sensor, RGB LED as status LED, and [MAX17048](https://www.analog.com/en/products/max17048.html) I2C battery charge monitor.
 
@@ -181,7 +181,7 @@ Per-device configs live in the repository root. Each sets `substitutions:` (devi
 - Select default Python interpreter and create virtual environment (Ctrl-Shift-P Python...).
 - Install ESPHome (in venv terminal): `pip install --upgrade [--pre] setuptools wheel platformio esphome`.
 - Make sure [ESPHome](https://esphome.io/guides/cli) is installed: `esphome version`.
-- Compile ESPHome project: `esphome compile esp32-s3-test.yaml`.
+- Compile ESPHome project: `esphome compile test/esp32-s3-devkitc.yaml`.
 - Launch Dashboard: `esphome dashboard .`, open [http://localhost:6052/](http://localhost:6052/).
 
 ### Debugging in DevContainer
@@ -194,14 +194,14 @@ Per-device configs live in the repository root. Each sets `substitutions:` (devi
 
 - Install Python from the Microsoft Store.
 - Setup [VSCode](#vscode-setup).
-- Compile ESPHome project: `esphome compile esp32-s3-feather-test.yaml`.
+- Compile ESPHome project: `esphome compile test/adafruit-esp32-s3-feather.yaml`.
 - Plugin device, hold Boot and press Reset if required.
 - List COM ports from PowerShell:
   - Serial ports: `[System.IO.Ports.SerialPort]::getportnames()`
   - Msft drivers: `Get-CimInstance -Class Win32_SerialPort | Select-Object Name, Description, DeviceID`.
   - Custom drivers: `Get-CimInstance -ClassName Win32_PnPEntity | Where-Object { $_.Name -match '.*\(COM(\d)\)' } Select-Object Caption`.
-- Upload firmware: `esphome run --device COM4 esp32-s3-feather-test.yaml`.
-- Log output: `esphome logs [--device COM5] esp32-s3-feather-test.yaml`.
+- Upload firmware: `esphome run --device COM4 test/adafruit-esp32-s3-feather.yaml`.
+- Log output: `esphome logs [--device COM5] test/adafruit-esp32-s3-feather.yaml`.
 
 ### Debugging on Windows WSL
 
@@ -222,7 +222,7 @@ Per-device configs live in the repository root. Each sets `substitutions:` (devi
 - Open VSCode Remote WSL Ubuntu session.
   - Setup [VSCode](#vscode-setup) in remote WSL session.
   - List COM ports: `ls /dev/tty*`.
-  - Upload firmware: `esphome run --device /dev/ttyUSB0 esp32-s3-test.yaml`
+  - Upload firmware: `esphome run --device /dev/ttyUSB0 test/esp32-s3-devkitc.yaml`
 - Unbind serial port.
   - Windows: `usbipd detach --busid 7-1`
   - Windows: `usbipd unbind --all`

--- a/cspell.json
+++ b/cspell.json
@@ -150,7 +150,6 @@
     "Norvi",
     "nuget",
     "nugetlibrary",
-    "Octa",
     "OLED",
     "onCreateCommand",
     "Oper",

--- a/cspell.json
+++ b/cspell.json
@@ -109,6 +109,7 @@
     "Iiot",
     "Improv",
     "insanegenius",
+    "IPEX",
     "isnan",
     "isort",
     "jadx",

--- a/templates/esp32-s3-devkitc.yaml
+++ b/templates/esp32-s3-devkitc.yaml
@@ -8,6 +8,7 @@
 # ESP32-S3-WROOM-1-N8       : 8MB  Quad Flash, 0MB      PSRAM, 3.3V SPI
 # ESP32-S3-WROOM-1-N8R2     : 8MB  Quad Flash, 2MB Quad PSRAM, 3.3V SPI
 # ESP32-S3-WROOM-1-N8R8     : 8MB  Quad Flash, 8MB Octa PSRAM, 3.3V SPI
+# ESP32-S3-WROOM-1-N16R8    : 16MB Quad Flash, 8MB Octa PSRAM, 3.3V SPI
 # ESP32-S3-WROOM-2-N16R8V   : 16MB Octa Flash, 8MB Octa PSRAM, 1.8V SPI
 # ESP32-S3-WROOM-2-N32R8V   : 32MB Octa Flash, 8MB Octa PSRAM, 1.8V SPI
 # ESP32-S3-DEVKITC-1-N32R8V : 32MB Octa Flash, 8MB Octa PSRAM, 1.8V SPI
@@ -16,7 +17,7 @@
 # ESP32-S3-DEVKITC-1U-N8R8  : 8MB  Quad Flash, 8MB Octa PSRAM, 3.3V SPI
 
 # GPIO35, GPIO36, GPIO37 : Octal SPI flash PSRAM
-# GPIO38 : RGB LED
+# GPIO38 : RGB LED on board v1.1, GPIO48 on v1.0 and most clones, override rgb_led_pin to match
 # GPIO43, GPIO44 : SiLabs CP210x USB-UART
 # GPIO19, GPIO20 : USB-CDC
 

--- a/templates/esp32-s3-devkitc.yaml
+++ b/templates/esp32-s3-devkitc.yaml
@@ -3,18 +3,23 @@
 # device_friendly_name
 
 # Espressif ESP32-S3-DevKitC-1/1U
-# https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
+# https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html
 
-# ESP32-S3-WROOM-1-N8       : 8MB  Quad Flash, 0MB      PSRAM, 3.3V SPI
-# ESP32-S3-WROOM-1-N8R2     : 8MB  Quad Flash, 2MB Quad PSRAM, 3.3V SPI
-# ESP32-S3-WROOM-1-N8R8     : 8MB  Quad Flash, 8MB Octa PSRAM, 3.3V SPI
-# ESP32-S3-WROOM-1-N16R8    : 16MB Quad Flash, 8MB Octa PSRAM, 3.3V SPI
-# ESP32-S3-WROOM-2-N16R8V   : 16MB Octa Flash, 8MB Octa PSRAM, 1.8V SPI
-# ESP32-S3-WROOM-2-N32R8V   : 32MB Octa Flash, 8MB Octa PSRAM, 1.8V SPI
-# ESP32-S3-DEVKITC-1-N32R8V : 32MB Octa Flash, 8MB Octa PSRAM, 1.8V SPI
-# ESP32-S3-WROOM-1U-N8      : 8MB  Quad Flash, 0MB      PSRAM, 3.3V SPI
-# ESP32-S3-WROOM-1U-N8R2    : 8MB  Quad Flash, 2MB Quad PSRAM, 3.3V SPI
-# ESP32-S3-DEVKITC-1U-N8R8  : 8MB  Quad Flash, 8MB Octa PSRAM, 3.3V SPI
+# Module datasheets
+# ESP32-S3-WROOM-1/1U : https://documentation.espressif.com/esp32-s3-wroom-1_wroom-1u_datasheet_en.html
+# ESP32-S3-WROOM-2    : https://www.espressif.com/sites/default/files/documentation/esp32-s3-wroom-2_datasheet_en.pdf
+
+# Module memory configurations
+# ESP32-S3-WROOM-1-N8       : 8MB  Quad  Flash, 0MB       PSRAM, 3.3V SPI
+# ESP32-S3-WROOM-1-N8R2     : 8MB  Quad  Flash, 2MB Quad  PSRAM, 3.3V SPI
+# ESP32-S3-WROOM-1-N8R8     : 8MB  Quad  Flash, 8MB Octal PSRAM, 3.3V SPI
+# ESP32-S3-WROOM-1-N16R8    : 16MB Quad  Flash, 8MB Octal PSRAM, 3.3V SPI
+# ESP32-S3-WROOM-2-N16R8V   : 16MB Octal Flash, 8MB Octal PSRAM, 1.8V SPI
+# ESP32-S3-WROOM-2-N32R8V   : 32MB Octal Flash, 8MB Octal PSRAM, 1.8V SPI
+# ESP32-S3-DEVKITC-1-N32R8V : 32MB Octal Flash, 8MB Octal PSRAM, 1.8V SPI
+# ESP32-S3-WROOM-1U-N8      : 8MB  Quad  Flash, 0MB       PSRAM, 3.3V SPI
+# ESP32-S3-WROOM-1U-N8R2    : 8MB  Quad  Flash, 2MB Quad  PSRAM, 3.3V SPI
+# ESP32-S3-DEVKITC-1U-N8R8  : 8MB  Quad  Flash, 8MB Octal PSRAM, 3.3V SPI
 
 # GPIO35, GPIO36, GPIO37 : Octal SPI flash PSRAM
 # GPIO38 : RGB LED on board v1.1, GPIO48 on v1.0 and most clones, override rgb_led_pin to match

--- a/templates/esp32-s3-wroom-1-n16r8.yaml
+++ b/templates/esp32-s3-wroom-1-n16r8.yaml
@@ -5,7 +5,7 @@
 # Board definition overlay for esp32-s3-devkitc.yaml, whose default board is the
 # ESP32-S3-WROOM-1-N8, 8MB Quad Flash and no PSRAM.
 # WROOM-1 and WROOM-1U differ only in PCB antenna versus IPEX connector, and are identical to program.
-# Espressif does not list an N16R8 DevKitC-1 SKU, so these boards are third party builds of the module.
+# Espressif does not list an N16R8 DevKitC-1 SKU, so these boards are third-party builds of the module.
 # Set rgb_led_pin per board, DevKitC-1 v1.0 clones use GPIO48 and v1.1 uses the GPIO38 default.
 
 # Module is rated -40 to 65 C ambient, check against the mounting location.

--- a/templates/esp32-s3-wroom-1-n16r8.yaml
+++ b/templates/esp32-s3-wroom-1-n16r8.yaml
@@ -1,0 +1,25 @@
+# ESP32-S3-WROOM-1-N16R8 / ESP32-S3-WROOM-1U-N16R8
+# ESP32-S3R8, 16MB Quad SPI Flash, 8MB Octal SPI PSRAM, 3.3V SPI
+# https://documentation.espressif.com/esp32-s3-wroom-1_wroom-1u_datasheet_en.html
+
+# Board definition overlay for esp32-s3-devkitc.yaml, whose default board is the
+# ESP32-S3-WROOM-1-N8, 8MB Quad Flash and no PSRAM.
+# WROOM-1 and WROOM-1U differ only in PCB antenna versus IPEX connector, and are identical to program.
+# Espressif does not list an N16R8 DevKitC-1 SKU, so these boards are third party builds of the module.
+# Set rgb_led_pin per board, DevKitC-1 v1.0 clones use GPIO48 and v1.1 uses the GPIO38 default.
+
+# Module is rated -40 to 65 C ambient, check against the mounting location.
+
+# GPIO35, GPIO36, GPIO37 : Octal SPI PSRAM
+
+# Keep in sync with esp32-s3-wroom-2-n16r8v.yaml and esp32-s3-wroom-2-n32r8v.yaml
+
+# https://esphome.io/components/esp32
+esp32:
+  flash_size: 16MB
+
+# https://esphome.io/components/psram
+# ESPHome has no default mode on the S3, which supports both quad and octal PSRAM.
+psram:
+  mode: octal
+  speed: 80MHz

--- a/templates/esp32-s3-wroom-2-n16r8v.yaml
+++ b/templates/esp32-s3-wroom-2-n16r8v.yaml
@@ -4,24 +4,20 @@
 
 # GPIO35, GPIO36, GPIO37 : Octal SPI flash PSRAM
 
-# Similar config to ESP32-S3-WROOM-2-N32R8V but with 16MB Flash
-# Keep in sync with esp32-s3-wroom-2-n32r8v.yaml
+# Same board as ESP32-S3-WROOM-2-N32R8V but with 16MB Flash, and no OTA restriction at this size.
+# Keep in sync with esp32-s3-wroom-2-n32r8v.yaml and esp32-s3-wroom-1-n16r8.yaml
 
-# https://esphome.io/guides/configuration-types.html#local-packages
-packages:
-  # Modify changes from 32MB to 16MB in esp32-s3-wroom-2-n32r8v.yaml
-  n32r8v: !include esp32-s3-wroom-2-n32r8v.yaml
+# See the Octal flash mode TODO in esp32-s3-wroom-2-n32r8v.yaml, it applies to this module too.
 
-# https://esphome.io/components/esphome
-esphome:
-  platformio_options:
-    board_build.arduino.partitions: default_16MB.csv
-    board_name: "Espressif ESP32-S3-WROOM-2-N16R8V (ESP32-S3R8V, 16MB Octal SPI Flash, 8MB Octal SPI PSRAM, 1.8V SPI)"
-    board_upload.maximum_size: 16777216
+# Modifies the default esp32-s3-devkitc-1 board configuration, 8MB Quad Flash and no PSRAM.
+# Declared standalone rather than deriving from the 32MB template, which leaked its settings in here.
+# That left this 16MB build with CONFIG_ESPTOOLPY_FLASHSIZE_32MB and the 32MB-only experimental opt-in.
 
 # https://esphome.io/components/esp32
 esp32:
   flash_size: 16MB
-  framework:
-    sdkconfig_options:
-      CONFIG_ESPTOOLPY_FLASHSIZE_16MB: "y"
+
+# https://esphome.io/components/psram
+psram:
+  mode: octal
+  speed: 80MHz

--- a/templates/esp32-s3-wroom-2-n32r8v.yaml
+++ b/templates/esp32-s3-wroom-2-n32r8v.yaml
@@ -10,7 +10,12 @@
 
 # GPIO35, GPIO36, GPIO37 : Octal SPI flash PSRAM
 
-# Keep in sync with esp32-s3-wroom-2-n16r8v.yaml
+# Keep in sync with esp32-s3-wroom-2-n16r8v.yaml and esp32-s3-wroom-1-n16r8.yaml
+
+# TODO: Declare the Octal flash mode instead of letting IDF correct it at boot.
+# ESPHome supports `flash_mode: opi`, and the generated sdkconfig currently has CONFIG_ESPTOOLPY_FLASHMODE_DIO.
+# That matches the boot log warning below, where IDF detects the mismatch and switches to Octal itself.
+# Not changed here because it alters flash timing and cannot be validated without the hardware.
 
 # TODO: Boot log warnings
 # "spi_flash: Octal flash chip is using but dio mode is selected, will automatically swich to Octal mode"
@@ -21,44 +26,17 @@
 # Use max 16MB flash else OTA does not work
 # https://github.com/esphome/issues/issues/5824
 
-# https://esphome.io/components/esphome
-esphome:
-
-  # Modify default esp32-s3-devkitc-1 (8MB Flash, no PSRAM) board configuration
-  platformio_options:
-
-    # https://github.com/espressif/arduino-esp32/tree/master/tools/partitions
-    board_build.arduino.partitions: large_littlefs_32MB.csv
-    # Octal memory type for Flash and PSRAM
-    board_build.arduino.memory_type: opi_opi
-    # TODO: Per devs adding psram in YAML should auto add -DBOARD_HAS_PSRAM, could not confirm
-    board_build.extra_flags:
-      - "-DARDUINO_ESP32S3_DEV"
-      - "-DBOARD_HAS_PSRAM"
-      - "-DARDUINO_USB_MODE=1"
-      - "-DARDUINO_RUNNING_CORE=1"
-      - "-DARDUINO_EVENT_RUNNING_CORE=1"
-    # Octal memory type for PSRAM
-    board_build.psram_type: opi
-    board_name: "Espressif ESP32-S3-WROOM-2-N32R8V (ESP32-S3R8V, 32MB Octal SPI Flash, 8MB Octal SPI PSRAM, 1.8V SPI)"
-    # TODO: https://github.com/esphome/issues/issues/5404
-    # TODO: Error when setting flash size in board config?
-    # "Please specify flash_size within esp32 configuration only.""
-    # board_upload.flash_size: 32MB
-    # 32MB
-    board_upload.maximum_size: 33554432
+# Modifies the default esp32-s3-devkitc-1 board configuration, 8MB Quad Flash and no PSRAM.
+# ESPHome derives the sdkconfig flash size, the partition table, and the upload size from flash_size.
+# It derives the PSRAM sdkconfig from psram, so neither is declared by hand any more.
+# The former platformio_options block only ever applied to the Arduino framework, not to esp-idf.
 
 # https://esphome.io/components/esp32
 esp32:
-
-  # TODO: Why can't we set flash size in board config?
   flash_size: 32MB
 
   # https://esphome.io/components/esp32#esp-idf-framework
   framework:
-    # "Warning! Flash memory size mismatch detected. Expected 32MB, found 2MB!"
-    sdkconfig_options:
-      CONFIG_ESPTOOLPY_FLASHSIZE_32MB: "y"
     # ESPHome rejects 32MB flash with OTA unless experimental IDF features are opted in.
     # common.yaml always pulls OTA in, so the opt-in is required to build at all.
     # This does not fix the OTA limitation in the TODO above, 16MB remains the safer choice.

--- a/test/esp32-s3-wroom-1-n16r8.yaml
+++ b/test/esp32-s3-wroom-1-n16r8.yaml
@@ -1,0 +1,12 @@
+# CI compile-test for templates/esp32-s3-wroom-1-n16r8.yaml
+# The board definition is an overlay, not a standalone device.
+# Composed on the devkit template, as esp32-s3-devkitc.yaml documents.
+substitutions:
+  device_name: esp32-s3-wroom1-n16r8-test
+  device_friendly_name: "ESP32-S3-WROOM-1-N16R8 Test"
+  # Third party N16R8 boards commonly follow the DevKitC-1 v1.0 layout, RGB LED on GPIO48 not GPIO38.
+  rgb_led_pin: GPIO48
+
+packages:
+  device: !include ../templates/esp32-s3-devkitc.yaml
+  board: !include ../templates/esp32-s3-wroom-1-n16r8.yaml

--- a/test/esp32-s3-wroom-1-n16r8.yaml
+++ b/test/esp32-s3-wroom-1-n16r8.yaml
@@ -4,7 +4,7 @@
 substitutions:
   device_name: esp32-s3-wroom1-n16r8-test
   device_friendly_name: "ESP32-S3-WROOM-1-N16R8 Test"
-  # Third party N16R8 boards commonly follow the DevKitC-1 v1.0 layout, RGB LED on GPIO48 not GPIO38.
+  # Third-party N16R8 boards commonly follow the DevKitC-1 v1.0 layout, RGB LED on GPIO48 not GPIO38.
   rgb_led_pin: GPIO48
 
 packages:


### PR DESCRIPTION
Adds a board template for the ESP32-S3-WROOM-1-N16R8 module, 16MB Quad SPI Flash and 8MB Octal SPI PSRAM, as the candidate host for an HVAC Bluetooth proxy. The stock `esp32-s3-devkitc-1` board is the N8 module with 8MB flash and no PSRAM, so this configuration could not be built before.

## New template

`templates/esp32-s3-wroom-1-n16r8.yaml` is a memory overlay on `esp32-s3-devkitc.yaml`, matching how the WROOM-2 definitions are consumed. It declares only `flash_size: 16MB` and `psram: {mode: octal, speed: 80MHz}`; `board:` stays on the base, so there is one source of truth.

WROOM-1 and WROOM-1U differ only in PCB antenna versus IPEX connector and are identical to program, so one template covers both.

## WROOM-2 modernization

ESPHome now derives the sdkconfig flash size, the partition table, and the upload size from `flash_size:`, and the PSRAM sdkconfig from `psram:`. The hand-written `platformio_options` in the WROOM-2 templates only ever applied to the Arduino framework (`psram/__init__.py` gates them behind `if CORE.using_arduino`), and these templates are `esp-idf`. They were inert.

Proof rather than assertion: the generated `sdkconfig` and `partitions.csv` for the 32MB board are **byte identical** before and after the strip.

`esp32-s3-wroom-2-n16r8v.yaml` is now standalone instead of deriving from the 32MB template. Deriving leaked the parent's settings into the 16MB build:

```
CONFIG_ESPTOOLPY_FLASHSIZE="32MB"          ->  "16MB"
CONFIG_IDF_EXPERIMENTAL_FEATURES=y         ->  not set
CONFIG_BOOTLOADER_FLASH_32BIT_ADDR=y       ->  removed
CONFIG_SPI_FLASH_32BIT_ADDR_ENABLE         ->  removed
```

The 16MB board was building a bootloader with 32-bit flash addressing, which only applies above 16MB, while its partition table was correctly sized for 16MB. The two disagreed.

## Also

- Document the DevKitC-1 RGB LED move from GPIO48 (v1.0 and most clones) to GPIO38 (v1.1), overridable via the existing `rgb_led_pin` substitution.
- Record a TODO for declaring `flash_mode: opi` on the octal-flash WROOM-2 boards. The generated sdkconfig has `FLASHMODE_DIO`, matching the boot log warning already recorded in that template where IDF detects the mismatch and switches to Octal itself. Left unchanged because it alters flash timing and cannot be validated without the hardware.
- Point the README debugging steps at `test/` configs; the root configs they referenced no longer exist.

## Verification

- All 18 test configs validate; the new board compiles with `FLASHSIZE_16MB`, `SPIRAM_MODE_OCT`, `SPIRAM_SPEED_80M`, and a 16MB partition layout.
- Both WROOM-2 boards recompile clean, with the sdkconfig diffs above.
- The CI matrix is generated from `test/`, so the new template is picked up automatically and the coverage guard requires its example device. Expect 18 legs.
- markdownlint, cspell, editorconfig-checker clean.

Note that the RGB LED pin cannot be confirmed until the board is in hand. If it stays dark on GPIO48, GPIO38 is the other candidate, and it is a one-line substitution either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)