### PR TITLE
Compare against a stock-component EasyStart config, and add a WiFi RSSI interval knob

### DIFF
--- a/easystart/ESPHOME-BLE-ISSUE.md
+++ b/easystart/ESPHOME-BLE-ISSUE.md
@@ -185,6 +185,13 @@ Event 6 is `ESP_GATTC_SEARCH_CMPL_EVT` and event 38 is `ESP_GATTC_REG_FOR_NOTIFY
 
 [Defect 2][defect-2] suppresses the release entirely for any client carrying a `ble_client` action or passkey trigger, and with it this crash. Reproducing defect 1 requires a configuration free of those nodes, which is why the harness above drives its reconnects from a `lambda` calling `disconnect()` rather than the `ble_client.disconnect` action.
 
+An unrelated third-party configuration for the same hardware shows both effects together. [Keen-coffee/home_assistant][keen-coffee-easystart] reads the same EasyStart modules using only stock components, and is protected twice over:
+
+- Its `ble_client.disconnect` action never reports `ESTABLISHED`, so `all_nodes_established_()` is permanently false for that client and the release never runs at all. That is defect 2 masking defect 1, in a configuration written without any knowledge of either.
+- Its subscription is the stock `ble_client` characteristic sensor with `notify: true`, which establishes in `ESP_GATTC_REG_FOR_NOTIFY_EVT` after checking the status. Even with the actions removed, the ordering would still be correct.
+
+What separates a configuration that crashes from one that does not is therefore whether a node assigns `node_state` itself, not how elaborate the configuration is. The stock nodes that subscribe to notifications order it correctly, so the undocumented contract only reaches code that implements `BLEClientNode` directly. That configuration also pays defect 2's cost in exchange: those services stay allocated for the life of every connection.
+
 ### Fix
 
 Two independent changes, either of which prevents the crash.
@@ -291,6 +298,7 @@ That is a workaround, not a fix. It amounts to a component obeying a rule that i
 [disconnect-action]: https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/automation.h#L367-L375
 [disconnect-trigger]: https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/automation.h#L38-L61
 [issue-17437]: https://github.com/esphome/esphome/issues/17437
+[keen-coffee-easystart]: https://github.com/Keen-coffee/home_assistant/blob/main/easyStart
 [numeric-comparison]: https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/automation.h#L84-L93
 [node-state]: https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/ble_client.h#L34-L37
 [passkey-notification]: https://github.com/esphome/esphome/blob/72f904dcfbb119c9454f440e313416f828f8ee35/esphome/components/ble_client/automation.h#L73-L82

--- a/templates/wifi.yaml
+++ b/templates/wifi.yaml
@@ -1,10 +1,17 @@
 # Required substitutions:
 # device_name
 
+# Optional substitutions:
+# wifi_signal_update_interval (60s, drop it to a few seconds to survey placement)
+
 # Required secrets:
 # wifi_ssid
 # wifi_password
 # wifi_domain
+
+# https://esphome.io/components/substitutions
+substitutions:
+  wifi_signal_update_interval: 60s
 
 # https://esphome.io/components/wifi
 wifi:
@@ -33,3 +40,4 @@ sensor:
   # https://esphome.io/components/sensor/wifi_signal
   - platform: wifi_signal
     name: "WiFi Signal"
+    update_interval: ${wifi_signal_update_interval}


### PR DESCRIPTION
Promotes `develop` to `main`.

## Comparison against a stock-component EasyStart configuration

[Keen-coffee/home_assistant](https://github.com/Keen-coffee/home_assistant/blob/main/easyStart) reads the same Micro-Air EasyStart modules using only stock ESPHome components. It cannot hit the crash described in `easystart/ESPHOME-BLE-ISSUE.md`, and it is protected twice over:

- Its `ble_client.disconnect` action never reports `ESTABLISHED`, so `all_nodes_established_()` is permanently false for that client and `release_services()` never runs. That is the second defect masking the first, in a configuration written with no knowledge of either.
- Its subscription is the stock `ble_client` characteristic sensor with `notify: true`, which establishes in `ESP_GATTC_REG_FOR_NOTIFY_EVT` after checking the status. Even with the actions removed the ordering would still be correct.

This matters for the upstream report. It turns the "why this is rarely hit" argument from an inference about the bundled components into an observation of a real configuration, and it shows what actually separates a crashing configuration from a safe one: whether a node assigns `node_state` itself, not how elaborate the configuration is. The undocumented contract only reaches code that implements `BLEClientNode` directly.

## WiFi signal interval knob

`templates/wifi.yaml` gains `wifi_signal_update_interval`, defaulting to `60s`, which is the interval the `wifi_signal` sensor already used. Placement surveys can now raise the sample rate per device rather than editing a template shared by every device.

Verified that the other consumers resolve unchanged at `60s` (`garage-presence-sensor`, `recirculation-pump-controller`, `living-room-plant-sensor`). The GL-S10 proxy has no `wifi_signal` sensor, being PoE.

## Not included

The 5s survey overrides on `hvac-compressor-sensor.yaml` are deliberately left uncommitted in the working tree. They exist to walk candidate mounting positions and belong with that exercise, not on `main`.

## Verification

- `esphome config` clean for `hvac-compressor-sensor.yaml` and the other WiFi consumers.
- `markdownlint`, `cspell`, `editorconfig-checker`, `actionlint` clean.
