### PR TITLE
Read the live API client count for the RGB status LED

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -195,8 +195,10 @@ Do not `!remove` blocks from Apollo's package without checking what depends on t
 
 - **The status source is polled, deliberately.** ESPHome has a `wifi:` `on_connect` and an `ethernet:` `on_connect` but no network-level trigger, and YAML has no conditionals, so no single event-driven form covers both interfaces. A 1s `interval` edge-detects instead and runs the script only on a change.
 - **`network::is_connected()` is the interface-agnostic helper.** It resolves Ethernet, modem, WiFi, and OpenThread behind their own `USE_*` defines, so the C++ already does the conditional compilation that the YAML cannot. Its header is in the generated `src/esphome.h` for both WiFi and Ethernet builds, so a lambda needs no include. Do not "fix" this back to a `wifi:` trigger.
+- **The API state is read live, never latched into a global.** `api:` accepts `max_connections` clients, so a flag set by `on_client_connected` and cleared by `on_client_disconnected` goes false the moment any one of them leaves and stays false while Home Assistant is still connected. That is a white LED on a device Home Assistant reports online, and the earlier version of this template had exactly that bug. The `api.connected` condition reads `APIServer::is_connected()`, the live connection count, and upstream fires the disconnect trigger *after* removing the client so the condition sees the true state from inside it. The two triggers stay, but only to re-run the script.
+- **Any second client is enough to trip it**, a leaked `esphome logs` session included, so see [Logs and the API Connection Cap][api-connection-cap] for reaping them.
 - **It is remotely consumable**, needing only the `rgb_led_pin` substitution, so it must stay free of repo-local `!include` entries.
-- **It contributes its own `api:` block** for the `on_client_connected` triggers, which enables the API server rather than requiring one. A config composing this package alone validates with an unencrypted API, so an encryption key comes from `api.yaml` or from the composing config.
+- **It contributes its own `api:` block** for the client triggers and the `api.connected` condition, which enables the API server rather than requiring one. A config composing this package alone validates with an unencrypted API, so an encryption key comes from `api.yaml` or from the composing config.
 
 ### Bootloader Age and USB Flashing
 
@@ -479,6 +481,7 @@ Sharp edges in the tooling around this repository, each one learned by tripping 
 
 [agents-write-safety]: ./AGENTS.md#repository-boundaries-and-write-safety
 [agents]: ./AGENTS.md
+[api-connection-cap]: #logs-and-the-api-connection-cap
 [apollo-template]: ./templates/apollo-plt-1b.yaml
 [ble-issue]: ./easystart/ESPHOME-BLE-ISSUE.md
 [ble-re-playbook]: ./easystart/BLE-RE-PLAYBOOK.md

--- a/templates/rgb-led-status.yaml
+++ b/templates/rgb-led-status.yaml
@@ -16,7 +16,7 @@
 
 # Status colors, all steady, highest state reached wins.
 # - Green : an API client is connected, the device is fully up.
-# - White : the network is up but no API client has connected, so Home Assistant is not talking to it.
+# - White : the network is up but no API client is connected, so Home Assistant is not talking to it.
 # - Yellow: boot finished with no network, so check cabling, DHCP, or WiFi credentials.
 # - Red   : still booting, and red that never leaves is a boot loop.
 
@@ -45,9 +45,6 @@ globals:
   - id: network_ok
     type: bool
     initial_value: "false"
-  - id: api_ok
-    type: bool
-    initial_value: "false"
 
 # https://esphome.io/components/esphome
 esphome:
@@ -62,15 +59,15 @@ esphome:
         - lambda: id(boot_done) = true;
         - script.execute: led_system_status
 
+# The server accepts several clients at once, so the triggers only prompt a re-evaluation.
+# A latched flag would clear on any one client leaving while the others still hold the color.
 # https://esphome.io/components/api
 api:
   on_client_connected:
     then:
-      - lambda: id(api_ok) = true;
       - script.execute: led_system_status
   on_client_disconnected:
     then:
-      - lambda: id(api_ok) = false;
       - script.execute: led_system_status
 
 # ESPHome has no network-level connect trigger, so poll the interface-agnostic helper.
@@ -130,7 +127,7 @@ script:
       # An API client is connected, green.
       - if:
           condition:
-            lambda: return id(api_ok);
+            api.connected:
           then:
             - light.turn_on:
                 id: system_status_led


### PR DESCRIPTION
The status LED on a deployed proxy sat white while Home Assistant held an unbroken API connection and every entity was live.

The connected color was driven by an `api_ok` global, set in `on_client_connected` and cleared in `on_client_disconnected`. The API server accepts `max_connections` clients, 5 by default, so any one of them disconnecting cleared the flag for all of them. Nothing re-evaluated while Home Assistant stayed connected, so the LED latched white until some new client happened to connect.

The `api.connected` condition reads `APIServer::is_connected()`, the live connection count, so it cannot be wrong about a client that is still there. Upstream fires the disconnect trigger after removing the client, so the condition reads the true state from inside it. The two triggers stay, but only to re-run the script.

## Verification

`esphome config` passes for every consumer of the template: both Bluetooth proxies, the HVAC compressor sensor, and the eight `test/` devices whose board templates include it.

The fix is flashed to the office proxy. With one log client attached alongside Home Assistant, a second client was connected and then disconnected. The disconnect fires the trigger and re-drives the LED green, `0% / 100% / 10%`, because two clients remain. Before the change the same sequence set it white, `70% / 70% / 70%`.
