### PR TITLE
Add the Elecrow ThinkNode M7 template with CH390 ethernet

### DIFF
--- a/ch390/components/ethernet/__init__.py
+++ b/ch390/components/ethernet/__init__.py
@@ -479,6 +479,12 @@ SPI_SCHEMA = _spi_schema()
 # of spec for it and makes the driver's CS hold time helper compute no hold
 SPI_SCHEMA_ENC28J60 = _spi_schema(default_clock="20MHz", max_clock=int(20e6))
 
+# The CH390H/D rates SCK at 50 MHz typical and 72 MHz maximum with VDDIO at 3.3V,
+# so the shared 80 MHz ceiling is out of spec while the 26.67 MHz default is not.
+# CH390 datasheet v1.8, tables 9-4 and 9-5:
+# https://www.wch-ic.com/downloads/CH390DS1_PDF.html
+SPI_SCHEMA_CH390 = _spi_schema(max_clock=int(72e6))
+
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
         {
@@ -493,7 +499,7 @@ CONFIG_SCHEMA = cv.All(
             "W5500": SPI_SCHEMA,
             "OPENETH": cv.All(BASE_SCHEMA, cv.only_on([Platform.ESP32])),
             "DM9051": SPI_SCHEMA,
-            "CH390": SPI_SCHEMA,
+            "CH390": SPI_SCHEMA_CH390,
             "ENC28J60": SPI_SCHEMA_ENC28J60,
             "W6100": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
             "W6300": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),

--- a/ch390/components/ethernet/__init__.py
+++ b/ch390/components/ethernet/__init__.py
@@ -1,0 +1,820 @@
+from dataclasses import dataclass
+import logging
+
+from esphome import automation, pins
+from esphome.automation import Condition
+import esphome.codegen as cg
+from esphome.components.network import add_use_address, ip_address_literal
+from esphome.config_helpers import filter_source_files_from_platform
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ADDRESS,
+    CONF_CLK_PIN,
+    CONF_CS_PIN,
+    CONF_DNS1,
+    CONF_DNS2,
+    CONF_DOMAIN,
+    CONF_ENABLE_ON_BOOT,
+    CONF_GATEWAY,
+    CONF_ID,
+    CONF_INTERRUPT_PIN,
+    CONF_MAC_ADDRESS,
+    CONF_MANUAL_IP,
+    CONF_MISO_PIN,
+    CONF_MODE,
+    CONF_MOSI_PIN,
+    CONF_NUMBER,
+    CONF_ON_CONNECT,
+    CONF_ON_DISCONNECT,
+    CONF_PAGE_ID,
+    CONF_PIN,
+    CONF_POLLING_INTERVAL,
+    CONF_RESET_PIN,
+    CONF_SPI,
+    CONF_STATIC_IP,
+    CONF_SUBNET,
+    CONF_TYPE,
+    CONF_USE_ADDRESS,
+    CONF_VALUE,
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
+    Platform,
+    PlatformFramework,
+)
+from esphome.core import (
+    CORE,
+    CoroPriority,
+    TimePeriodMilliseconds,
+    coroutine_with_priority,
+)
+import esphome.final_validate as fv
+from esphome.types import ConfigType
+
+CONFLICTS_WITH = ["wifi"]
+AUTO_LOAD = ["network"]
+LOGGER = logging.getLogger(__name__)
+
+# Key for tracking IP state listener count in CORE.data
+ETHERNET_IP_STATE_LISTENERS_KEY = "ethernet_ip_state_listeners"
+# Key for tracking configured ethernet type
+ETHERNET_TYPE_KEY = "ethernet_type"
+KEY_ETHERNET = "ethernet"
+
+
+def request_ethernet_ip_state_listener() -> None:
+    """Request an IP state listener slot.
+
+    Components that implement EthernetIPStateListener should call this
+    in their to_code() to register for IP state notifications.
+    """
+    CORE.data[ETHERNET_IP_STATE_LISTENERS_KEY] = (
+        CORE.data.get(ETHERNET_IP_STATE_LISTENERS_KEY, 0) + 1
+    )
+
+
+# RMII pins that are hardcoded on ESP32 classic and cannot be changed
+# These pins are used by the internal Ethernet MAC when using RMII PHYs
+ESP32_RMII_FIXED_PINS = {
+    19: "EMAC_TXD0",
+    21: "EMAC_TX_EN",
+    22: "EMAC_TXD1",
+    25: "EMAC_RXD0",
+    26: "EMAC_RXD1",
+    27: "EMAC_RX_CRS_DV",
+}
+
+# RMII default pins for ESP32-P4
+# These are the default pins used by ESP-IDF and are configurable in principle,
+# but ESPHome's ethernet component currently has no way to change them
+ESP32P4_RMII_DEFAULT_PINS = {
+    34: "EMAC_TXD0",
+    35: "EMAC_TXD1",
+    28: "EMAC_RX_CRS_DV",
+    29: "EMAC_RXD0",
+    30: "EMAC_RXD1",
+    49: "EMAC_TX_EN",
+}
+
+ethernet_ns = cg.esphome_ns.namespace("ethernet")
+PHYRegister = ethernet_ns.struct("PHYRegister")
+CONF_PHY_ADDR = "phy_addr"
+CONF_MDC_PIN = "mdc_pin"
+CONF_MDIO_PIN = "mdio_pin"
+CONF_CLK = "clk"
+CONF_CLK_MODE = "clk_mode"
+CONF_POWER_PIN = "power_pin"
+CONF_PHY_REGISTERS = "phy_registers"
+
+CONF_INTERFACE = "interface"
+
+CONF_CLOCK_SPEED = "clock_speed"
+
+EthernetType = ethernet_ns.enum("EthernetType")
+ETHERNET_TYPES = {
+    "LAN8720": EthernetType.ETHERNET_TYPE_LAN8720,
+    "RTL8201": EthernetType.ETHERNET_TYPE_RTL8201,
+    "DP83848": EthernetType.ETHERNET_TYPE_DP83848,
+    "IP101": EthernetType.ETHERNET_TYPE_IP101,
+    "JL1101": EthernetType.ETHERNET_TYPE_JL1101,
+    "KSZ8081": EthernetType.ETHERNET_TYPE_KSZ8081,
+    "KSZ8081RNA": EthernetType.ETHERNET_TYPE_KSZ8081RNA,
+    "W5100": EthernetType.ETHERNET_TYPE_W5100,
+    "W5500": EthernetType.ETHERNET_TYPE_W5500,
+    "OPENETH": EthernetType.ETHERNET_TYPE_OPENETH,
+    "DM9051": EthernetType.ETHERNET_TYPE_DM9051,
+    "LAN8670": EthernetType.ETHERNET_TYPE_LAN8670,
+    "ENC28J60": EthernetType.ETHERNET_TYPE_ENC28J60,
+    "W6100": EthernetType.ETHERNET_TYPE_W6100,
+    "W6300": EthernetType.ETHERNET_TYPE_W6300,
+    "GENERIC": EthernetType.ETHERNET_TYPE_GENERIC,
+    "YT8531": EthernetType.ETHERNET_TYPE_YT8531,
+    "CH390": EthernetType.ETHERNET_TYPE_CH390,
+}
+
+# PHY types that need compile-time defines for conditional compilation
+# Each RMII PHY type gets a define so unused PHY drivers are excluded by the linker
+_PHY_TYPE_TO_DEFINE = {
+    "LAN8720": "USE_ETHERNET_LAN8720",
+    "RTL8201": "USE_ETHERNET_RTL8201",
+    "DP83848": "USE_ETHERNET_DP83848",
+    "IP101": "USE_ETHERNET_IP101",
+    "JL1101": "USE_ETHERNET_JL1101",
+    "KSZ8081": "USE_ETHERNET_KSZ8081",
+    "KSZ8081RNA": "USE_ETHERNET_KSZ8081",
+    "W5100": "USE_ETHERNET_W5100",
+    "W5500": "USE_ETHERNET_W5500",
+    "DM9051": "USE_ETHERNET_DM9051",
+    "LAN8670": "USE_ETHERNET_LAN8670",
+    "ENC28J60": "USE_ETHERNET_ENC28J60",
+    "W6100": "USE_ETHERNET_W6100",
+    "W6300": "USE_ETHERNET_W6300",
+    "GENERIC": "USE_ETHERNET_GENERIC",
+    "YT8531": "USE_ETHERNET_YT8531",
+    "CH390": "USE_ETHERNET_CH390",
+}
+
+
+@dataclass(frozen=True)
+class IDFRegistryComponent:
+    """An ESP-IDF component from the Espressif Component Registry."""
+
+    name: str
+    version: str
+
+
+# IDF 6.0 moved per-chip PHY/MAC drivers to the Espressif Component Registry.
+_IDF6_ETHERNET_COMPONENTS: dict[str, IDFRegistryComponent] = {
+    "LAN8720": IDFRegistryComponent("espressif/lan87xx", "1.0.0"),
+    "RTL8201": IDFRegistryComponent("espressif/rtl8201", "1.0.1"),
+    "DP83848": IDFRegistryComponent("espressif/dp83848", "1.0.0"),
+    "IP101": IDFRegistryComponent("espressif/ip101", "1.0.0"),
+    "KSZ8081": IDFRegistryComponent("espressif/ksz80xx", "1.0.0"),
+    "KSZ8081RNA": IDFRegistryComponent("espressif/ksz80xx", "1.0.0"),
+    "W5500": IDFRegistryComponent("espressif/w5500", "1.0.1"),
+    "DM9051": IDFRegistryComponent("espressif/dm9051", "1.1.0"),
+    "ENC28J60": IDFRegistryComponent("espressif/enc28j60", "1.0.1"),
+    "LAN8670": IDFRegistryComponent("espressif/lan867x", "2.0.0"),
+    "CH390": IDFRegistryComponent("espressif/ch390", "0.3.0"),
+}
+
+# These types are always external IDF components (never built-in to ESP-IDF)
+_ALWAYS_EXTERNAL_IDF_COMPONENTS = {"LAN8670", "ENC28J60", "CH390"}
+
+# ESP32-only SPI ethernet types (W5100 is RP2040-only, no ESP-IDF driver)
+SPI_ETHERNET_TYPES = {"W5500", "DM9051", "ENC28J60", "CH390"}
+# RP2-supported ethernet types (SPI and PIO QSPI). Applies to the whole
+# RP2 family (RP2040 and RP2350); the chip-specific W5100 caveat in the
+# comment above is about ESP-IDF driver coverage, not the RP2 platform.
+RP2_ETHERNET_TYPES = {"W5100", "W5500", "W6100", "W6300", "ENC28J60"}
+_RP2_SPI_LIBRARIES = {
+    "W5100": "lwIP_w5100",
+    "W5500": "lwIP_w5500",
+    "ENC28J60": "lwIP_enc28j60",
+    "W6100": "lwIP_w6100",
+    "W6300": "lwIP_w6300",
+}
+SPI_ETHERNET_DEFAULT_POLLING_INTERVAL = TimePeriodMilliseconds(milliseconds=10)
+
+emac_rmii_clock_mode_t = cg.global_ns.enum("emac_rmii_clock_mode_t")
+
+CLK_MODES = {
+    "CLK_EXT_IN": emac_rmii_clock_mode_t.EMAC_CLK_EXT_IN,
+    "CLK_OUT": emac_rmii_clock_mode_t.EMAC_CLK_OUT,
+}
+
+CLK_MODES_DEPRECATED = {
+    "GPIO0_IN": ("CLK_EXT_IN", 0),
+    "GPIO0_OUT": ("CLK_OUT", 0),
+    "GPIO16_OUT": ("CLK_OUT", 16),
+    "GPIO17_OUT": ("CLK_OUT", 17),
+}
+
+spi_host_device_t = cg.global_ns.enum("spi_host_device_t")
+
+SPI_INTERFACE_MAP = {
+    "spi2": spi_host_device_t.SPI2_HOST,
+    "spi3": spi_host_device_t.SPI3_HOST,
+}
+
+MANUAL_IP_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_STATIC_IP): cv.ipv4address,
+        cv.Required(CONF_GATEWAY): cv.ipv4address,
+        cv.Required(CONF_SUBNET): cv.ipv4address,
+        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipv4address,
+        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipv4address,
+    }
+)
+
+EthernetComponent = ethernet_ns.class_("EthernetComponent", cg.Component)
+ManualIP = ethernet_ns.struct("ManualIP")
+EthernetConnectedCondition = ethernet_ns.class_("EthernetConnectedCondition", Condition)
+EthernetEnabledCondition = ethernet_ns.class_("EthernetEnabledCondition", Condition)
+EthernetEnableAction = ethernet_ns.class_("EthernetEnableAction", automation.Action)
+EthernetDisableAction = ethernet_ns.class_("EthernetDisableAction", automation.Action)
+
+
+def _is_framework_spi_polling_mode_supported() -> bool:
+    """Check if ESP-IDF framework supports SPI polling mode (ESP32 only).
+
+    SPI Ethernet without IRQ feature is added in
+    esp-idf >= (5.3+, 5.2.1+, 5.1.4)
+    """
+    if not CORE.is_esp32:
+        return False
+    from esphome.components.esp32 import idf_version
+
+    ver = idf_version()
+    if ver >= cv.Version(5, 3, 0):
+        return True
+    if cv.Version(5, 3, 0) > ver >= cv.Version(5, 2, 1):
+        return True
+    if cv.Version(5, 2, 0) > ver >= cv.Version(5, 1, 4):  # noqa: SIM103
+        return True
+    return False
+
+
+def _validate_spi_interface(config: ConfigType) -> ConfigType:
+    """Set default SPI interface or validate user choice against the variant."""
+    if not CORE.is_esp32:
+        return config
+    from esphome.components.esp32 import VARIANT_ESP32, get_esp32_variant
+    from esphome.components.spi import get_hw_interface_list
+
+    has_spi3 = "spi3" in sum(get_hw_interface_list(), [])
+    if CONF_INTERFACE not in config:
+        # Only classic ESP32 defaults to spi3; all others default to spi2
+        config[CONF_INTERFACE] = (
+            "spi3" if get_esp32_variant() == VARIANT_ESP32 else "spi2"
+        )
+    elif config[CONF_INTERFACE] == "spi3" and not has_spi3:
+        raise cv.Invalid("Interface 'spi3' is not available on this variant.")
+    return config
+
+
+def _validate(config):
+    if CONF_USE_ADDRESS not in config:
+        if CONF_MANUAL_IP in config:
+            use_address = str(config[CONF_MANUAL_IP][CONF_STATIC_IP])
+        else:
+            use_address = CORE.name + config[CONF_DOMAIN]
+        config[CONF_USE_ADDRESS] = use_address
+
+    if CORE.is_esp32:
+        if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
+            # ENC28J60 driver does not support polling mode - interrupt is required
+            if config[CONF_TYPE] == "ENC28J60":
+                if CONF_POLLING_INTERVAL in config:
+                    raise cv.Invalid(
+                        f"'{CONF_POLLING_INTERVAL}' is not supported for ENC28J60. "
+                        f"'{CONF_INTERRUPT_PIN}' is required."
+                    )
+                if CONF_INTERRUPT_PIN not in config:
+                    raise cv.Invalid(
+                        f"'{CONF_INTERRUPT_PIN}' is a required option for ENC28J60."
+                    )
+            elif _is_framework_spi_polling_mode_supported():
+                if CONF_POLLING_INTERVAL in config and CONF_INTERRUPT_PIN in config:
+                    raise cv.Invalid(
+                        f"Cannot specify more than one of {CONF_INTERRUPT_PIN}, {CONF_POLLING_INTERVAL}"
+                    )
+                if (
+                    CONF_POLLING_INTERVAL not in config
+                    and CONF_INTERRUPT_PIN not in config
+                ):
+                    config[CONF_POLLING_INTERVAL] = (
+                        SPI_ETHERNET_DEFAULT_POLLING_INTERVAL
+                    )
+            else:
+                if CONF_POLLING_INTERVAL in config:
+                    raise cv.Invalid(
+                        "In this version of the framework "
+                        f"({CORE.target_framework} {CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]}), "
+                        f"'{CONF_POLLING_INTERVAL}' is not supported."
+                    )
+                if CONF_INTERRUPT_PIN not in config:
+                    raise cv.Invalid(
+                        "In this version of the framework "
+                        f"({CORE.target_framework} {CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]}), "
+                        f"'{CONF_INTERRUPT_PIN}' is a required option for [ethernet]."
+                    )
+        elif config[CONF_TYPE] in ("GENERIC", "YT8531"):
+            from esphome.components.esp32 import (
+                VARIANT_ESP32S31,
+                get_esp32_variant,
+                idf_version,
+            )
+
+            eth_type = config[CONF_TYPE]
+            variant = get_esp32_variant()
+            if variant != VARIANT_ESP32S31:
+                raise cv.Invalid(
+                    f"The '{eth_type}' (RGMII) PHY is only supported on gigabit-capable "
+                    f"variants (ESP32-S31), not {variant}"
+                )
+            if idf_version() < cv.Version(6, 0, 0):
+                raise cv.Invalid(
+                    f"The '{eth_type}' (RGMII) PHY requires ESP-IDF 6.0 or newer."
+                )
+        elif config[CONF_TYPE] != "OPENETH":
+            from esphome.components.esp32 import (
+                VARIANT_ESP32,
+                VARIANT_ESP32P4,
+                get_esp32_variant,
+            )
+
+            if CONF_CLK_MODE in config:
+                mode, pin = CLK_MODES_DEPRECATED[config[CONF_CLK_MODE]]
+                LOGGER.warning(
+                    "[ethernet] The 'clk_mode' option is deprecated. "
+                    "Please replace 'clk_mode: %s' with:\n"
+                    "  clk:\n"
+                    "    mode: %s\n"
+                    "    pin: %s\n"
+                    "Removal scheduled for 2026.9.0.",
+                    config[CONF_CLK_MODE],
+                    mode,
+                    pin,
+                )
+                config[CONF_CLK] = CLK_SCHEMA({CONF_MODE: mode, CONF_PIN: pin})
+                del config[CONF_CLK_MODE]
+            elif CONF_CLK not in config:
+                raise cv.Invalid("'clk' is a required option for [ethernet].")
+            variant = get_esp32_variant()
+            if variant not in (VARIANT_ESP32, VARIANT_ESP32P4):
+                raise cv.Invalid(
+                    f"{config[CONF_TYPE]} PHY requires RMII interface and is only supported "
+                    f"on ESP32 classic and ESP32-P4, not {variant}"
+                )
+    elif CORE.is_rp2 and config[CONF_TYPE] not in RP2_ETHERNET_TYPES:
+        raise cv.Invalid(
+            f"Only {', '.join(sorted(RP2_ETHERNET_TYPES))} are supported on the RP2 "
+            f"platform, not {config[CONF_TYPE]}"
+        )
+    return config
+
+
+BASE_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(EthernetComponent),
+        cv.Optional(CONF_MANUAL_IP): MANUAL_IP_SCHEMA,
+        cv.Optional(CONF_DOMAIN, default=".local"): cv.domain_name,
+        cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
+        cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
+        cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
+        cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(single=True),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+PHY_REGISTER_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ADDRESS): cv.hex_int,
+        cv.Required(CONF_VALUE): cv.hex_int,
+        cv.Optional(CONF_PAGE_ID): cv.hex_int,
+    }
+)
+CLK_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_MODE): cv.enum(CLK_MODES, upper=True, space="_"),
+        cv.Required(CONF_PIN): pins.internal_gpio_pin_number,
+    }
+)
+RMII_SCHEMA = cv.All(
+    BASE_SCHEMA.extend(
+        cv.Schema(
+            {
+                cv.Required(CONF_MDC_PIN): pins.internal_gpio_output_pin_number,
+                cv.Required(CONF_MDIO_PIN): pins.internal_gpio_output_pin_number,
+                cv.Optional(CONF_CLK_MODE): cv.enum(
+                    CLK_MODES_DEPRECATED, upper=True, space="_"
+                ),
+                cv.Optional(CONF_CLK): CLK_SCHEMA,
+                cv.Optional(CONF_PHY_ADDR, default=0): cv.int_range(min=0, max=31),
+                cv.Optional(CONF_POWER_PIN): pins.internal_gpio_output_pin_number,
+                cv.Optional(CONF_PHY_REGISTERS): cv.ensure_list(PHY_REGISTER_SCHEMA),
+            }
+        )
+    ),
+    cv.only_on([Platform.ESP32]),
+)
+
+# Generic IEEE 802.3 PHY over the internal EMAC RGMII interface (e.g. ESP32-S31).
+# RGMII data pins come from the IDF per-target default config.
+GENERIC_SCHEMA = cv.All(
+    BASE_SCHEMA.extend(
+        cv.Schema(
+            {
+                cv.Required(CONF_MDC_PIN): pins.internal_gpio_output_pin_number,
+                cv.Required(CONF_MDIO_PIN): pins.internal_gpio_output_pin_number,
+                cv.Optional(CONF_PHY_ADDR, default=0): cv.int_range(min=0, max=31),
+                cv.Optional(CONF_POWER_PIN): pins.internal_gpio_output_pin_number,
+                cv.Optional(CONF_PHY_REGISTERS): cv.ensure_list(PHY_REGISTER_SCHEMA),
+            }
+        )
+    ),
+    cv.only_on([Platform.ESP32]),
+)
+
+
+def _spi_schema(default_clock: str = "26.67MHz", max_clock: int = int(80e6)):
+    return cv.All(
+        BASE_SCHEMA.extend(
+            cv.Schema(
+                {
+                    cv.Required(CONF_CLK_PIN): pins.internal_gpio_output_pin_number,
+                    cv.Required(CONF_MISO_PIN): pins.internal_gpio_input_pin_number,
+                    cv.Required(CONF_MOSI_PIN): pins.internal_gpio_output_pin_number,
+                    cv.Required(CONF_CS_PIN): pins.internal_gpio_output_pin_number,
+                    cv.Optional(
+                        CONF_INTERRUPT_PIN
+                    ): pins.internal_gpio_input_pin_number,
+                    cv.Optional(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
+                    cv.SplitDefault(CONF_CLOCK_SPEED, esp32=default_clock): cv.All(
+                        cv.only_on_esp32,
+                        cv.frequency,
+                        cv.int_range(int(8e6), max_clock),
+                    ),
+                    cv.Optional(CONF_INTERFACE): cv.All(
+                        cv.only_on_esp32,
+                        cv.one_of(*SPI_INTERFACE_MAP.keys(), lower=True),
+                    ),
+                    # Set default value (SPI_ETHERNET_DEFAULT_POLLING_INTERVAL) at _validate()
+                    cv.Optional(CONF_POLLING_INTERVAL): cv.All(
+                        cv.only_on_esp32,
+                        cv.positive_time_period_milliseconds,
+                        cv.Range(min=TimePeriodMilliseconds(milliseconds=1)),
+                    ),
+                }
+            ),
+        ),
+        cv.only_on([Platform.ESP32, Platform.RP2]),
+        _validate_spi_interface,
+    )
+
+
+SPI_SCHEMA = _spi_schema()
+
+# The ENC28J60's SCK maximum is 20 MHz, so the shared 26.67 MHz default is out
+# of spec for it and makes the driver's CS hold time helper compute no hold
+SPI_SCHEMA_ENC28J60 = _spi_schema(default_clock="20MHz", max_clock=int(20e6))
+
+CONFIG_SCHEMA = cv.All(
+    cv.typed_schema(
+        {
+            "LAN8720": RMII_SCHEMA,
+            "RTL8201": RMII_SCHEMA,
+            "DP83848": RMII_SCHEMA,
+            "IP101": RMII_SCHEMA,
+            "JL1101": RMII_SCHEMA,
+            "KSZ8081": RMII_SCHEMA,
+            "KSZ8081RNA": RMII_SCHEMA,
+            "W5100": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
+            "W5500": SPI_SCHEMA,
+            "OPENETH": cv.All(BASE_SCHEMA, cv.only_on([Platform.ESP32])),
+            "DM9051": SPI_SCHEMA,
+            "CH390": SPI_SCHEMA,
+            "ENC28J60": SPI_SCHEMA_ENC28J60,
+            "W6100": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
+            "W6300": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2])),
+            "LAN8670": RMII_SCHEMA,
+            "GENERIC": GENERIC_SCHEMA,
+            "YT8531": GENERIC_SCHEMA,
+        },
+        upper=True,
+    ),
+    _validate,
+)
+
+
+def _final_validate_spi(config):
+    if not CORE.is_esp32:
+        return  # SPI interface validation is ESP32-only
+    if config[CONF_TYPE] not in SPI_ETHERNET_TYPES:
+        return
+    from esphome.components.spi import CONF_INTERFACE_INDEX, get_spi_interface
+
+    if spi_configs := fv.full_config.get().get(CONF_SPI):
+        # get_spi_interface() returns strings like "SPI2_HOST"
+        spi_host = f"{config[CONF_INTERFACE].upper()}_HOST"
+        for spi_conf in spi_configs:
+            if (index := spi_conf.get(CONF_INTERFACE_INDEX)) is not None:
+                interface = get_spi_interface(index)
+                if interface == spi_host:
+                    raise cv.Invalid(
+                        f"The `ethernet` and `spi` components are both using interface '{interface}'. "
+                        f"To use {config[CONF_TYPE]}, change the `interface` on either `ethernet:` or `spi:`."
+                    )
+
+
+def manual_ip(config):
+    return cg.StructInitializer(
+        ManualIP,
+        ("static_ip", ip_address_literal(config[CONF_STATIC_IP])),
+        ("gateway", ip_address_literal(config[CONF_GATEWAY])),
+        ("subnet", ip_address_literal(config[CONF_SUBNET])),
+        ("dns1", ip_address_literal(config[CONF_DNS1])),
+        ("dns2", ip_address_literal(config[CONF_DNS2])),
+    )
+
+
+def phy_register(address: int, value: int, page: int):
+    return cg.StructInitializer(
+        PHYRegister,
+        ("address", address),
+        ("value", value),
+        ("page", page),
+    )
+
+
+@coroutine_with_priority(CoroPriority.COMMUNICATION)
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    if CORE.is_esp32:
+        await _to_code_esp32(var, config)
+    elif CORE.is_rp2:
+        await _to_code_rp2040(var, config)
+
+    cg.add(var.set_type(ETHERNET_TYPES[config[CONF_TYPE]]))
+    add_use_address(var, config[CONF_USE_ADDRESS])
+    # enable_on_boot defaults to true in C++ - only set if false
+    if not config[CONF_ENABLE_ON_BOOT]:
+        cg.add(var.set_enable_on_boot(False))
+    CORE.data.setdefault(KEY_ETHERNET, {})[ETHERNET_TYPE_KEY] = config[CONF_TYPE]
+
+    if CONF_MANUAL_IP in config:
+        cg.add_define("USE_ETHERNET_MANUAL_IP")
+        cg.add(var.set_manual_ip(manual_ip(config[CONF_MANUAL_IP])))
+
+    # Add compile-time define for PHY types with specific code
+    if phy_define := _PHY_TYPE_TO_DEFINE.get(config[CONF_TYPE]):
+        cg.add_define(phy_define)
+
+    if mac_address := config.get(CONF_MAC_ADDRESS):
+        cg.add(var.set_fixed_mac(mac_address.parts))
+
+    cg.add_define("USE_ETHERNET")
+
+    if on_connect_config := config.get(CONF_ON_CONNECT):
+        cg.add_define("USE_ETHERNET_CONNECT_TRIGGER")
+        await automation.build_automation(
+            var.get_connect_trigger(), [], on_connect_config
+        )
+
+    if on_disconnect_config := config.get(CONF_ON_DISCONNECT):
+        cg.add_define("USE_ETHERNET_DISCONNECT_TRIGGER")
+        await automation.build_automation(
+            var.get_disconnect_trigger(), [], on_disconnect_config
+        )
+
+    CORE.add_job(final_step)
+
+
+async def _to_code_esp32(var: cg.Pvariable, config: ConfigType) -> None:
+    from esphome.components.esp32 import (
+        add_idf_component,
+        add_idf_sdkconfig_option,
+        idf_version,
+        include_builtin_idf_component,
+        request_ethernet,
+    )
+
+    if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
+        cg.add(var.set_clk_pin(config[CONF_CLK_PIN]))
+        cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
+        cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
+        cg.add(var.set_cs_pin(config[CONF_CS_PIN]))
+        if CONF_INTERRUPT_PIN in config:
+            cg.add(var.set_interrupt_pin(config[CONF_INTERRUPT_PIN]))
+        else:
+            cg.add(var.set_polling_interval(config[CONF_POLLING_INTERVAL]))
+        if _is_framework_spi_polling_mode_supported():
+            cg.add_define("USE_ETHERNET_SPI_POLLING_SUPPORT")
+        if CONF_RESET_PIN in config:
+            cg.add(var.set_reset_pin(config[CONF_RESET_PIN]))
+        cg.add(var.set_clock_speed(config[CONF_CLOCK_SPEED]))
+
+        cg.add_define("USE_ETHERNET_SPI")
+
+        cg.add(var.set_interface(SPI_INTERFACE_MAP[config[CONF_INTERFACE]]))
+        add_idf_sdkconfig_option("CONFIG_ETH_USE_SPI_ETHERNET", True)
+        # CONFIG_ETH_SPI_ETHERNET_{TYPE} Kconfig options were removed in IDF 6.0
+        # Types that are never built into IDF ship no Kconfig option at all
+        if (
+            idf_version() < cv.Version(6, 0, 0)
+            and config[CONF_TYPE] not in _ALWAYS_EXTERNAL_IDF_COMPONENTS
+        ):
+            add_idf_sdkconfig_option(
+                f"CONFIG_ETH_SPI_ETHERNET_{config[CONF_TYPE]}", True
+            )
+    elif config[CONF_TYPE] == "OPENETH":
+        cg.add_define("USE_ETHERNET_OPENETH")
+        add_idf_sdkconfig_option("CONFIG_ETH_USE_OPENETH", True)
+    elif config[CONF_TYPE] in ("GENERIC", "YT8531"):
+        # RGMII data pins come from the IDF default config; set MDC/MDIO + PHY addr.
+        cg.add(var.set_phy_addr(config[CONF_PHY_ADDR]))
+        cg.add(var.set_mdc_pin(config[CONF_MDC_PIN]))
+        cg.add(var.set_mdio_pin(config[CONF_MDIO_PIN]))
+        if CONF_POWER_PIN in config:
+            cg.add(var.set_power_pin(config[CONF_POWER_PIN]))
+        for register_value in config.get(CONF_PHY_REGISTERS, []):
+            reg = phy_register(
+                register_value.get(CONF_ADDRESS),
+                register_value.get(CONF_VALUE),
+                register_value.get(CONF_PAGE_ID),
+            )
+            cg.add(var.add_phy_register(reg))
+    else:
+        cg.add(var.set_phy_addr(config[CONF_PHY_ADDR]))
+        cg.add(var.set_mdc_pin(config[CONF_MDC_PIN]))
+        cg.add(var.set_mdio_pin(config[CONF_MDIO_PIN]))
+        cg.add(var.set_clk_mode(config[CONF_CLK][CONF_MODE]))
+        cg.add(var.set_clk_pin(config[CONF_CLK][CONF_PIN]))
+        if CONF_POWER_PIN in config:
+            cg.add(var.set_power_pin(config[CONF_POWER_PIN]))
+        for register_value in config.get(CONF_PHY_REGISTERS, []):
+            reg = phy_register(
+                register_value.get(CONF_ADDRESS),
+                register_value.get(CONF_VALUE),
+                register_value.get(CONF_PAGE_ID),
+            )
+            cg.add(var.add_phy_register(reg))
+
+    # Register Ethernet with the esp32 sdkconfig reconciler, which disables the
+    # WiFi stack and WiFi/BT coexistence when Ethernet is used without WiFi.
+    request_ethernet()
+
+    # Re-enable ESP-IDF's Ethernet driver (excluded by default to save compile time)
+    include_builtin_idf_component("esp_eth")
+
+    if config[CONF_TYPE] in _ALWAYS_EXTERNAL_IDF_COMPONENTS:
+        component = _IDF6_ETHERNET_COMPONENTS[config[CONF_TYPE]]
+        add_idf_component(name=component.name, ref=component.version)
+    elif idf_version() >= cv.Version(6, 0, 0) and (
+        # IDF 6.0 moved per-chip PHY/MAC drivers to the Espressif Component Registry
+        component := _IDF6_ETHERNET_COMPONENTS.get(config[CONF_TYPE])
+    ):
+        add_idf_component(name=component.name, ref=component.version)
+
+
+async def _to_code_rp2040(var: cg.Pvariable, config: ConfigType) -> None:
+    cg.add(var.set_clk_pin(config[CONF_CLK_PIN]))
+    cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
+    cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
+    cg.add(var.set_cs_pin(config[CONF_CS_PIN]))
+    if CONF_INTERRUPT_PIN in config:
+        cg.add(var.set_interrupt_pin(config[CONF_INTERRUPT_PIN]))
+    if CONF_RESET_PIN in config:
+        cg.add(var.set_reset_pin(config[CONF_RESET_PIN]))
+
+    cg.add_define("USE_ETHERNET_SPI")
+    cg.add_library(_RP2_SPI_LIBRARIES[config[CONF_TYPE]], None)
+
+
+def _final_validate_rmii_pins(config: ConfigType) -> None:
+    """Validate that RMII pins are not used by other components."""
+    if not CORE.is_esp32:
+        return  # RMII validation is ESP32-only
+    # Only validate for RMII-based PHYs on ESP32/ESP32P4
+    if config[CONF_TYPE] in SPI_ETHERNET_TYPES or config[CONF_TYPE] == "OPENETH":
+        return  # SPI and OPENETH don't use RMII
+
+    from esphome.components.esp32 import (
+        VARIANT_ESP32,
+        VARIANT_ESP32P4,
+        get_esp32_variant,
+    )
+
+    variant = get_esp32_variant()
+    if variant == VARIANT_ESP32:
+        rmii_pins = ESP32_RMII_FIXED_PINS
+        is_configurable = False
+    elif variant == VARIANT_ESP32P4:
+        rmii_pins = ESP32P4_RMII_DEFAULT_PINS
+        is_configurable = True
+    else:
+        return  # No RMII validation needed for other variants
+
+    # Check all used pins against RMII reserved pins
+    for pin_list in pins.PIN_SCHEMA_REGISTRY.pins_used.values():
+        for pin_path, pin_device, pin_config in pin_list:
+            pin_num = pin_config.get(CONF_NUMBER)
+            if pin_num not in rmii_pins:
+                continue
+            # Skip if pin is not directly on ESP, but at some expander (device set to something else than 'None')
+            if pin_device is not None:
+                continue
+            # Found a conflict - show helpful error message
+            pin_function = rmii_pins[pin_num]
+            component_path = ".".join(str(p) for p in pin_path)
+            if is_configurable:
+                error_msg = (
+                    f"GPIO{pin_num} is used by Ethernet RMII "
+                    f"({pin_function}) with the current default "
+                    f"configuration. This conflicts with '{component_path}'. "
+                    f"Please choose a different GPIO pin for "
+                    f"'{component_path}'."
+                )
+            else:
+                error_msg = (
+                    f"GPIO{pin_num} is reserved for Ethernet RMII "
+                    f"({pin_function}) and cannot be used. This pin is "
+                    f"hardcoded by ESP-IDF and cannot be changed when using "
+                    f"RMII Ethernet PHYs. Please choose a different GPIO pin "
+                    f"for '{component_path}'."
+                )
+            raise cv.Invalid(error_msg, path=pin_path)
+
+
+def _final_validate(config: ConfigType) -> ConfigType:
+    """Final validation for Ethernet component."""
+    _final_validate_spi(config)
+    _final_validate_rmii_pins(config)
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
+async def final_step():
+    """Final code generation step to configure optional Ethernet features."""
+    if ip_state_count := CORE.data.get(ETHERNET_IP_STATE_LISTENERS_KEY, 0):
+        cg.add_define("USE_ETHERNET_IP_STATE_LISTENERS")
+        cg.add_define("ESPHOME_ETHERNET_IP_STATE_LISTENERS", ip_state_count)
+
+
+_platform_filter = filter_source_files_from_platform(
+    {
+        "ethernet_component_esp32.cpp": {
+            PlatformFramework.ESP32_IDF,
+            PlatformFramework.ESP32_ARDUINO,
+        },
+        "ethernet_component_rp2.cpp": {PlatformFramework.RP2_ARDUINO},
+        "esp_eth_phy_jl1101.c": {
+            PlatformFramework.ESP32_IDF,
+            PlatformFramework.ESP32_ARDUINO,
+        },
+    }
+)
+
+
+def _filter_source_files() -> list[str]:
+    excluded = _platform_filter()
+    eth_data = CORE.data.get(KEY_ETHERNET, {})
+    eth_type = eth_data.get(ETHERNET_TYPE_KEY)
+    # Only compile the custom JL1101 driver when JL1101 is configured
+    # and pioarduino doesn't have it builtin (IDF 5.4.2 to 5.x)
+    if eth_type != "JL1101":
+        excluded.append("esp_eth_phy_jl1101.c")
+    elif CORE.is_esp32 and not CORE.using_toolchain_esp_idf:
+        from esphome.components.esp32 import idf_version
+
+        # pioarduino has JL1101 builtin on IDF 5.4.2-5.x; exclude custom driver
+        # to avoid shadowing. Native IDF builds always need the custom driver.
+        if cv.Version(5, 4, 2) <= idf_version() < cv.Version(6, 0, 0):
+            excluded.append("esp_eth_phy_jl1101.c")
+    return excluded
+
+
+FILTER_SOURCE_FILES = _filter_source_files
+
+
+async def _new_pvariable_to_code(config, id_, template_arg, args):
+    return cg.new_Pvariable(id_, template_arg)
+
+
+for _name, _cls in (
+    ("ethernet.connected", EthernetConnectedCondition),
+    ("ethernet.enabled", EthernetEnabledCondition),
+):
+    automation.register_condition(_name, _cls, cv.Schema({}))(_new_pvariable_to_code)
+for _name, _cls in (
+    ("ethernet.enable", EthernetEnableAction),
+    ("ethernet.disable", EthernetDisableAction),
+):
+    automation.register_action(_name, _cls, cv.Schema({}), synchronous=True)(
+        _new_pvariable_to_code
+    )

--- a/ch390/components/ethernet/automation.h
+++ b/ch390/components/ethernet/automation.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+#ifdef USE_ETHERNET
+#include "ethernet_component.h"
+
+namespace esphome::ethernet {
+
+template<typename... Ts> class EthernetConnectedCondition final : public Condition<Ts...> {
+ public:
+  bool check(const Ts &...x) override { return global_eth_component->is_connected(); }
+};
+
+template<typename... Ts> class EthernetEnabledCondition final : public Condition<Ts...> {
+ public:
+  bool check(const Ts &...x) override { return global_eth_component->is_enabled(); }
+};
+
+template<typename... Ts> class EthernetEnableAction final : public Action<Ts...> {
+ public:
+  void play(const Ts &...x) override { global_eth_component->enable(); }
+};
+
+template<typename... Ts> class EthernetDisableAction final : public Action<Ts...> {
+ public:
+  void play(const Ts &...x) override { global_eth_component->disable(); }
+};
+
+}  // namespace esphome::ethernet
+#endif

--- a/ch390/components/ethernet/esp_eth_phy_jl1101.c
+++ b/ch390/components/ethernet/esp_eth_phy_jl1101.c
@@ -1,0 +1,347 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include <string.h>
+#include <stdlib.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_eth.h"
+#include "esp_eth_phy_802_3.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_rom_gpio.h"
+#include "esp_rom_sys.h"
+#include "esp_idf_version.h"
+
+#if defined(USE_ETHERNET_JL1101) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0) || \
+                                     ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 2) || !defined(PLATFORMIO))
+
+static const char *TAG = "jl1101";
+#define PHY_CHECK(a, str, goto_tag, ...) \
+  do { \
+    if (!(a)) { \
+      ESP_LOGE(TAG, "%s(%d): " str, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
+      goto goto_tag; \
+    } \
+  } while (0)
+
+/***************Vendor Specific Register***************/
+
+/**
+ * @brief PSR(Page Select Register)
+ *
+ */
+typedef union {
+  struct {
+    uint16_t page_select : 8; /* Select register page, default is 0 */
+    uint16_t reserved : 8;    /* Reserved */
+  };
+  uint16_t val;
+} psr_reg_t;
+#define ETH_PHY_PSR_REG_ADDR (0x1F)
+
+typedef struct {
+  esp_eth_phy_t parent;
+  esp_eth_mediator_t *eth;
+  int addr;
+  uint32_t reset_timeout_ms;
+  uint32_t autonego_timeout_ms;
+  eth_link_t link_status;
+  int reset_gpio_num;
+} phy_jl1101_t;
+
+static esp_err_t jl1101_page_select(phy_jl1101_t *jl1101, uint32_t page) {
+  esp_eth_mediator_t *eth = jl1101->eth;
+  psr_reg_t psr = {.page_select = page};
+  PHY_CHECK(eth->phy_reg_write(eth, jl1101->addr, ETH_PHY_PSR_REG_ADDR, psr.val) == ESP_OK, "write PSR failed", err);
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_update_link_duplex_speed(phy_jl1101_t *jl1101) {
+  esp_eth_mediator_t *eth = jl1101->eth;
+  eth_speed_t speed = ETH_SPEED_10M;
+  eth_duplex_t duplex = ETH_DUPLEX_HALF;
+  bmcr_reg_t bmcr;
+  bmsr_reg_t bmsr;
+  uint32_t peer_pause_ability = false;
+  anlpar_reg_t anlpar;
+  PHY_CHECK(jl1101_page_select(jl1101, 0) == ESP_OK, "select page 0 failed", err);
+  PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMSR_REG_ADDR, &(bmsr.val)) == ESP_OK, "read BMSR failed",
+            err);
+  PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_ANLPAR_REG_ADDR, &(anlpar.val)) == ESP_OK,
+            "read ANLPAR failed", err);
+  eth_link_t link = bmsr.link_status ? ETH_LINK_UP : ETH_LINK_DOWN;
+  /* check if link status changed */
+  if (jl1101->link_status != link) {
+    /* when link up, read negotiation result */
+    if (link == ETH_LINK_UP) {
+      PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, &(bmcr.val)) == ESP_OK, "read BMCR failed",
+                err);
+      if (bmcr.speed_select) {
+        speed = ETH_SPEED_100M;
+      } else {
+        speed = ETH_SPEED_10M;
+      }
+      if (bmcr.duplex_mode) {
+        duplex = ETH_DUPLEX_FULL;
+      } else {
+        duplex = ETH_DUPLEX_HALF;
+      }
+      PHY_CHECK(eth->on_state_changed(eth, ETH_STATE_SPEED, (void *) speed) == ESP_OK, "change speed failed", err);
+      PHY_CHECK(eth->on_state_changed(eth, ETH_STATE_DUPLEX, (void *) duplex) == ESP_OK, "change duplex failed", err);
+      /* if we're in duplex mode, and peer has the flow control ability */
+      if (duplex == ETH_DUPLEX_FULL && anlpar.symmetric_pause) {
+        peer_pause_ability = 1;
+      } else {
+        peer_pause_ability = 0;
+      }
+      PHY_CHECK(eth->on_state_changed(eth, ETH_STATE_PAUSE, (void *) peer_pause_ability) == ESP_OK,
+                "change pause ability failed", err);
+    }
+    PHY_CHECK(eth->on_state_changed(eth, ETH_STATE_LINK, (void *) link) == ESP_OK, "change link failed", err);
+    jl1101->link_status = link;
+  }
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_set_mediator(esp_eth_phy_t *phy, esp_eth_mediator_t *eth) {
+  PHY_CHECK(eth, "can't set mediator to null", err);
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  jl1101->eth = eth;
+  return ESP_OK;
+err:
+  return ESP_ERR_INVALID_ARG;
+}
+
+static esp_err_t jl1101_get_link(esp_eth_phy_t *phy) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  /* Updata information about link, speed, duplex */
+  PHY_CHECK(jl1101_update_link_duplex_speed(jl1101) == ESP_OK, "update link duplex speed failed", err);
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_reset(esp_eth_phy_t *phy) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  jl1101->link_status = ETH_LINK_DOWN;
+  esp_eth_mediator_t *eth = jl1101->eth;
+  bmcr_reg_t bmcr = {.reset = 1};
+  PHY_CHECK(eth->phy_reg_write(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, bmcr.val) == ESP_OK, "write BMCR failed", err);
+  /* Wait for reset complete */
+  uint32_t to = 0;
+  for (to = 0; to < jl1101->reset_timeout_ms / 50; to++) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+    PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, &(bmcr.val)) == ESP_OK, "read BMCR failed",
+              err);
+    if (!bmcr.reset) {
+      break;
+    }
+  }
+  PHY_CHECK(to < jl1101->reset_timeout_ms / 50, "reset timeout", err);
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_reset_hw(esp_eth_phy_t *phy) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  if (jl1101->reset_gpio_num >= 0) {
+    esp_rom_gpio_pad_select_gpio(jl1101->reset_gpio_num);
+    gpio_set_direction(jl1101->reset_gpio_num, GPIO_MODE_OUTPUT);
+    gpio_set_level(jl1101->reset_gpio_num, 0);
+    esp_rom_delay_us(100);  // insert min input assert time
+    gpio_set_level(jl1101->reset_gpio_num, 1);
+  }
+  return ESP_OK;
+}
+
+static esp_err_t jl1101_negotiate(esp_eth_phy_t *phy, eth_phy_autoneg_cmd_t cmd, bool *nego_state) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  esp_eth_mediator_t *eth = jl1101->eth;
+  /* in case any link status has changed, let's assume we're in link down status */
+  jl1101->link_status = ETH_LINK_DOWN;
+  /* Restart auto negotiation */
+  bmcr_reg_t bmcr = {
+      .speed_select = 1,     /* 100Mbps */
+      .duplex_mode = 1,      /* Full Duplex */
+      .en_auto_nego = 1,     /* Auto Negotiation */
+      .restart_auto_nego = 1 /* Restart Auto Negotiation */
+  };
+  PHY_CHECK(eth->phy_reg_write(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, bmcr.val) == ESP_OK, "write BMCR failed", err);
+  /* Wait for auto negotiation complete */
+  bmsr_reg_t bmsr;
+  uint32_t to = 0;
+  for (to = 0; to < jl1101->autonego_timeout_ms / 100; to++) {
+    vTaskDelay(pdMS_TO_TICKS(100));
+    PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMSR_REG_ADDR, &(bmsr.val)) == ESP_OK, "read BMSR failed",
+              err);
+    if (bmsr.auto_nego_complete) {
+      break;
+    }
+  }
+  /* Auto negotiation failed, maybe no network cable plugged in, so output a warning */
+  if (to >= jl1101->autonego_timeout_ms / 100) {
+    ESP_LOGW(TAG, "auto negotiation timeout");
+  }
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_pwrctl(esp_eth_phy_t *phy, bool enable) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  esp_eth_mediator_t *eth = jl1101->eth;
+  bmcr_reg_t bmcr;
+  PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, &(bmcr.val)) == ESP_OK, "read BMCR failed",
+            err);
+  if (!enable) {
+    /* Enable IEEE Power Down Mode */
+    bmcr.power_down = 1;
+  } else {
+    /* Disable IEEE Power Down Mode */
+    bmcr.power_down = 0;
+  }
+  PHY_CHECK(eth->phy_reg_write(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, bmcr.val) == ESP_OK, "write BMCR failed", err);
+  if (!enable) {
+    PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, &(bmcr.val)) == ESP_OK, "read BMCR failed",
+              err);
+    PHY_CHECK(bmcr.power_down == 1, "power down failed", err);
+  } else {
+    /* wait for power up complete */
+    uint32_t to = 0;
+    for (to = 0; to < jl1101->reset_timeout_ms / 10; to++) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_BMCR_REG_ADDR, &(bmcr.val)) == ESP_OK, "read BMCR failed",
+                err);
+      if (bmcr.power_down == 0) {
+        break;
+      }
+    }
+    PHY_CHECK(to < jl1101->reset_timeout_ms / 10, "power up timeout", err);
+  }
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_set_addr(esp_eth_phy_t *phy, uint32_t addr) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  jl1101->addr = addr;
+  return ESP_OK;
+}
+
+static esp_err_t jl1101_get_addr(esp_eth_phy_t *phy, uint32_t *addr) {
+  PHY_CHECK(addr, "addr can't be null", err);
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  *addr = jl1101->addr;
+  return ESP_OK;
+err:
+  return ESP_ERR_INVALID_ARG;
+}
+
+static esp_err_t jl1101_del(esp_eth_phy_t *phy) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  free(jl1101);
+  return ESP_OK;
+}
+
+static esp_err_t jl1101_advertise_pause_ability(esp_eth_phy_t *phy, uint32_t ability) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  esp_eth_mediator_t *eth = jl1101->eth;
+  /* Set PAUSE function ability */
+  anar_reg_t anar;
+  PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_ANAR_REG_ADDR, &(anar.val)) == ESP_OK, "read ANAR failed",
+            err);
+  if (ability) {
+    anar.asymmetric_pause = 1;
+    anar.symmetric_pause = 1;
+  } else {
+    anar.asymmetric_pause = 0;
+    anar.symmetric_pause = 0;
+  }
+  PHY_CHECK(eth->phy_reg_write(eth, jl1101->addr, ETH_PHY_ANAR_REG_ADDR, anar.val) == ESP_OK, "write ANAR failed", err);
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_init(esp_eth_phy_t *phy) {
+  phy_jl1101_t *jl1101 = __containerof(phy, phy_jl1101_t, parent);
+  esp_eth_mediator_t *eth = jl1101->eth;
+  // Detect PHY address
+  if (jl1101->addr == ESP_ETH_PHY_ADDR_AUTO) {
+    PHY_CHECK(esp_eth_phy_802_3_detect_phy_addr(eth, &jl1101->addr) == ESP_OK, "Detect PHY address failed", err);
+  }
+  /* Power on Ethernet PHY */
+  PHY_CHECK(jl1101_pwrctl(phy, true) == ESP_OK, "power control failed", err);
+  /* Reset Ethernet PHY */
+  PHY_CHECK(jl1101_reset(phy) == ESP_OK, "reset failed", err);
+  /* Check PHY ID */
+  phyidr1_reg_t id1;
+  phyidr2_reg_t id2;
+  PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_IDR1_REG_ADDR, &(id1.val)) == ESP_OK, "read ID1 failed", err);
+  PHY_CHECK(eth->phy_reg_read(eth, jl1101->addr, ETH_PHY_IDR2_REG_ADDR, &(id2.val)) == ESP_OK, "read ID2 failed", err);
+  PHY_CHECK(id1.oui_msb == 0x937C && id2.oui_lsb == 0x10 && id2.vendor_model == 0x2, "wrong chip ID", err);
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+static esp_err_t jl1101_deinit(esp_eth_phy_t *phy) {
+  /* Power off Ethernet PHY */
+  PHY_CHECK(jl1101_pwrctl(phy, false) == ESP_OK, "power control failed", err);
+  return ESP_OK;
+err:
+  return ESP_FAIL;
+}
+
+esp_eth_phy_t *esp_eth_phy_new_jl1101(const eth_phy_config_t *config) {
+  PHY_CHECK(config, "can't set phy config to null", err);
+  phy_jl1101_t *jl1101 = calloc(1, sizeof(phy_jl1101_t));
+  PHY_CHECK(jl1101, "calloc jl1101 failed", err);
+  jl1101->addr = config->phy_addr;
+  jl1101->reset_gpio_num = config->reset_gpio_num;
+  jl1101->reset_timeout_ms = config->reset_timeout_ms;
+  jl1101->link_status = ETH_LINK_DOWN;
+  jl1101->autonego_timeout_ms = config->autonego_timeout_ms;
+  jl1101->parent.reset = jl1101_reset;
+  jl1101->parent.reset_hw = jl1101_reset_hw;
+  jl1101->parent.init = jl1101_init;
+  jl1101->parent.deinit = jl1101_deinit;
+  jl1101->parent.set_mediator = jl1101_set_mediator;
+  jl1101->parent.autonego_ctrl = jl1101_negotiate;
+  jl1101->parent.get_link = jl1101_get_link;
+  jl1101->parent.pwrctl = jl1101_pwrctl;
+  jl1101->parent.get_addr = jl1101_get_addr;
+  jl1101->parent.set_addr = jl1101_set_addr;
+  jl1101->parent.advertise_pause_ability = jl1101_advertise_pause_ability;
+  jl1101->parent.del = jl1101_del;
+
+  return &(jl1101->parent);
+err:
+  return NULL;
+}
+
+#endif /* USE_ARDUINO */
+#endif /* USE_ESP32 */

--- a/ch390/components/ethernet/ethernet_component.cpp
+++ b/ch390/components/ethernet/ethernet_component.cpp
@@ -1,0 +1,34 @@
+#include "ethernet_component.h"
+
+#ifdef USE_ETHERNET
+
+#include "esphome/core/log.h"
+
+namespace esphome::ethernet {
+
+EthernetComponent *global_eth_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+EthernetComponent::EthernetComponent() { global_eth_component = this; }
+
+float EthernetComponent::get_setup_priority() const { return setup_priority::WIFI; }
+
+void EthernetComponent::set_type(EthernetType type) { this->type_ = type; }
+
+#ifdef USE_ETHERNET_MANUAL_IP
+void EthernetComponent::set_manual_ip(const ManualIP &manual_ip) { this->manual_ip_ = manual_ip; }
+#endif
+
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+void EthernetComponent::notify_ip_state_listeners_() {
+  auto ips = this->get_ip_addresses();
+  auto dns1 = this->get_dns_address(0);
+  auto dns2 = this->get_dns_address(1);
+  for (auto *listener : this->ip_state_listeners_) {
+    listener->on_ip_state(ips, dns1, dns2);
+  }
+}
+#endif  // USE_ETHERNET_IP_STATE_LISTENERS
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ETHERNET

--- a/ch390/components/ethernet/ethernet_component.h
+++ b/ch390/components/ethernet/ethernet_component.h
@@ -1,0 +1,367 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/network/ip_address.h"
+
+#ifdef USE_ETHERNET
+
+#ifdef USE_ESP32
+#include "esp_eth.h"
+#ifdef USE_ETHERNET_SPI
+#include "hal/spi_types.h"
+#endif
+#include "esp_eth_mac.h"
+#include "esp_eth_mac_esp.h"
+#include "esp_netif.h"
+#include "esp_mac.h"
+#include "esp_idf_version.h"
+
+#if CONFIG_ETH_USE_ESP32_EMAC
+extern "C" eth_esp32_emac_config_t eth_esp32_emac_default_config(void);
+#endif
+#endif  // USE_ESP32
+
+#ifdef USE_RP2
+#if defined(USE_ETHERNET_W5500)
+#include <W5500lwIP.h>
+#elif defined(USE_ETHERNET_W5100)
+#include <W5100lwIP.h>
+#elif defined(USE_ETHERNET_W6100)
+#include <W6100lwIP.h>
+#elif defined(USE_ETHERNET_W6300)
+#include <W6300lwIP.h>
+// W6300 uses PIO QSPI, not Arduino SPI. The upstream Wiznet6300 class
+// incorrectly returns needsSPI()=true, causing LwipIntfDev::begin() to
+// call SPI.begin() which claims GPIOs that PIO QSPI needs.
+// This wrapper hides needsSPI() with a version returning false.
+class Wiznet6300NoSPI : public Wiznet6300 {
+ public:
+  using Wiznet6300::Wiznet6300;
+  constexpr bool needsSPI() const { return false; }
+};
+using Wiznet6300lwIPFixed = LwipIntfDev<Wiznet6300NoSPI>;
+#elif defined(USE_ETHERNET_ENC28J60)
+#include <ENC28J60lwIP.h>
+#else
+#error "Unsupported RP2040 SPI Ethernet type"
+#endif
+#endif
+
+namespace esphome::ethernet {
+
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+/** Listener interface for Ethernet IP state changes.
+ *
+ * Components can implement this interface to receive IP address updates
+ * without the overhead of std::function callbacks or polling.
+ *
+ * @note Components must call ethernet.request_ethernet_ip_state_listener() in their
+ *       Python to_code() to register for this listener type.
+ */
+class EthernetIPStateListener {
+ public:
+  virtual void on_ip_state(const network::IPAddresses &ips, const network::IPAddress &dns1,
+                           const network::IPAddress &dns2) = 0;
+};
+#endif  // USE_ETHERNET_IP_STATE_LISTENERS
+
+enum EthernetType : uint8_t {
+  ETHERNET_TYPE_UNKNOWN = 0,
+  ETHERNET_TYPE_LAN8720,
+  ETHERNET_TYPE_RTL8201,
+  ETHERNET_TYPE_DP83848,
+  ETHERNET_TYPE_IP101,
+  ETHERNET_TYPE_JL1101,
+  ETHERNET_TYPE_KSZ8081,
+  ETHERNET_TYPE_KSZ8081RNA,
+  ETHERNET_TYPE_W5100,
+  ETHERNET_TYPE_W5500,
+  ETHERNET_TYPE_OPENETH,
+  ETHERNET_TYPE_DM9051,
+  ETHERNET_TYPE_LAN8670,
+  ETHERNET_TYPE_ENC28J60,
+  ETHERNET_TYPE_W6100,
+  ETHERNET_TYPE_W6300,
+  ETHERNET_TYPE_GENERIC,
+  ETHERNET_TYPE_YT8531,
+  ETHERNET_TYPE_CH390,
+};
+
+struct ManualIP {
+  network::IPAddress static_ip;
+  network::IPAddress gateway;
+  network::IPAddress subnet;
+  network::IPAddress dns1;  ///< The first DNS server. 0.0.0.0 for default.
+  network::IPAddress dns2;  ///< The second DNS server. 0.0.0.0 for default.
+};
+
+struct PHYRegister {
+  uint32_t address;
+  uint32_t value;
+  uint32_t page;
+};
+
+enum class EthernetComponentState : uint8_t {
+  STOPPED,
+  CONNECTING,
+  CONNECTED,
+};
+
+// Platform-neutral duplex/speed types
+#ifndef USE_ESP32
+enum eth_duplex_t { ETH_DUPLEX_HALF, ETH_DUPLEX_FULL };
+enum eth_speed_t { ETH_SPEED_10M, ETH_SPEED_100M };
+#endif
+
+class EthernetComponent final : public Component {
+ public:
+  EthernetComponent();
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  void on_powerdown() override { powerdown(); }
+  bool is_connected() { return this->state_ == EthernetComponentState::CONNECTED; }
+
+  // Per-interface lifecycle (parallels WiFiComponent::enable/disable/is_disabled).
+  // enable_on_boot defaults to true; when false, setup() runs all the driver/netif
+  // installation but skips esp_eth_start(), keeping the link cold until enable() is
+  // called. This is the primary lever for memory reclamation in multi-interface
+  // configurations where only one interface should carry traffic at a time.
+  void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
+  void enable();
+  void disable();
+  bool is_disabled() { return this->disabled_; }
+  bool is_enabled() { return !this->disabled_; }
+
+  void set_type(EthernetType type);
+#ifdef USE_ETHERNET_MANUAL_IP
+  void set_manual_ip(const ManualIP &manual_ip);
+#endif
+  void set_fixed_mac(const std::array<uint8_t, 6> &mac) { this->fixed_mac_ = mac; }
+
+  network::IPAddresses get_ip_addresses();
+  network::IPAddress get_dns_address(uint8_t num);
+  /// Returns nullptr when no explicit use_address is configured and the address is
+  /// derived at runtime from the device name (see network::get_use_address_to()).
+  const char *get_use_address() const { return this->use_address_; }
+  void set_use_address(const char *use_address) { this->use_address_ = use_address; }
+  void get_eth_mac_address_raw(uint8_t *mac);
+  // Remove before 2026.9.0
+  ESPDEPRECATED("Use get_eth_mac_address_pretty_into_buffer() instead. Removed in 2026.9.0", "2026.3.0")
+  std::string get_eth_mac_address_pretty();
+  const char *get_eth_mac_address_pretty_into_buffer(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf);
+  eth_duplex_t get_duplex_mode();
+  eth_speed_t get_link_speed();
+  bool powerdown();
+
+#ifdef USE_ESP32
+  esp_eth_handle_t get_eth_handle() const { return this->eth_handle_; }
+
+#ifdef USE_ETHERNET_SPI
+  void set_clk_pin(uint8_t clk_pin);
+  void set_miso_pin(uint8_t miso_pin);
+  void set_mosi_pin(uint8_t mosi_pin);
+  void set_cs_pin(uint8_t cs_pin);
+  void set_interrupt_pin(uint8_t interrupt_pin);
+  void set_reset_pin(uint8_t reset_pin);
+  void set_clock_speed(int clock_speed);
+  void set_interface(spi_host_device_t interface);
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+  void set_polling_interval(uint32_t polling_interval);
+#endif
+#else
+  void set_phy_addr(uint8_t phy_addr);
+  void set_power_pin(int power_pin);
+  void set_mdc_pin(uint8_t mdc_pin);
+  void set_mdio_pin(uint8_t mdio_pin);
+  void set_clk_pin(uint8_t clk_pin);
+  void set_clk_mode(emac_rmii_clock_mode_t clk_mode);
+  void add_phy_register(PHYRegister register_value);
+#endif  // USE_ETHERNET_SPI
+#endif  // USE_ESP32
+
+#ifdef USE_RP2
+  void set_clk_pin(uint8_t clk_pin);
+  void set_miso_pin(uint8_t miso_pin);
+  void set_mosi_pin(uint8_t mosi_pin);
+  void set_cs_pin(uint8_t cs_pin);
+  void set_interrupt_pin(int8_t interrupt_pin);
+  void set_reset_pin(int8_t reset_pin);
+#endif  // USE_RP2
+
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+  void add_ip_state_listener(EthernetIPStateListener *listener) { this->ip_state_listeners_.push_back(listener); }
+#endif
+
+#ifdef USE_ETHERNET_CONNECT_TRIGGER
+  Trigger<> *get_connect_trigger() { return &this->connect_trigger_; }
+#endif
+#ifdef USE_ETHERNET_DISCONNECT_TRIGGER
+  Trigger<> *get_disconnect_trigger() { return &this->disconnect_trigger_; }
+#endif
+
+ protected:
+  void start_connect_();
+  void finish_connect_();
+  void dump_connect_params_();
+
+#ifdef USE_ESP32
+  // ESP-IDF only: defers the SPI bus init, netif creation, MAC/PHY install, driver
+  // install, netif attach, and event handler registration (which together allocate
+  // ~3-8KB of DMA-capable internal SRAM via SPI driver state + eth driver RX queue)
+  // until ethernet actually needs to come up. Idempotent — guarded by the
+  // ethernet_initialized_ flag. Called from setup() when enable_on_boot_=true, or
+  // from enable() on first runtime enable. Mirrors wifi_lazy_init_() in WiFi.
+  void ethernet_lazy_init_();
+#endif
+
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+  void notify_ip_state_listeners_();
+#endif
+
+#ifdef USE_ESP32
+  static void eth_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+  static void got_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+#if LWIP_IPV6
+  static void got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+#endif /* LWIP_IPV6 */
+  void log_error_and_mark_failed_(esp_err_t err, const char *message);
+#ifdef USE_ETHERNET_KSZ8081
+  /// @brief Set `RMII Reference Clock Select` bit for KSZ8081.
+  void ksz8081_set_clock_reference_(esp_eth_mac_t *mac);
+#endif
+#ifdef USE_ETHERNET_YT8531
+  /// @brief Apply YT8531-specific config: re-enable auto-negotiation (disabled on
+  /// reset) and set the RGMII Tx/Rx clock delays needed for reliable data sampling.
+  void yt8531_phy_init_();
+#endif
+  /// @brief Set arbitratry PHY registers from config.
+  void write_phy_register_(esp_eth_mac_t *mac, PHYRegister register_data);
+
+#ifdef USE_ETHERNET_SPI
+  uint8_t clk_pin_;
+  uint8_t miso_pin_;
+  uint8_t mosi_pin_;
+  uint8_t cs_pin_;
+  int interrupt_pin_{-1};
+  int reset_pin_{-1};
+  int phy_addr_spi_{-1};
+  int clock_speed_;
+  spi_host_device_t interface_{SPI2_HOST};
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+  uint32_t polling_interval_{0};
+#endif
+#else
+  // Group all 32-bit members first
+  int power_pin_{-1};
+  emac_rmii_clock_mode_t clk_mode_{EMAC_CLK_EXT_IN};
+  std::vector<PHYRegister> phy_registers_{};
+
+  // Group all 8-bit members together
+  uint8_t clk_pin_{0};
+  uint8_t phy_addr_{0};
+  uint8_t mdc_pin_{23};
+  uint8_t mdio_pin_{18};
+#endif  // USE_ETHERNET_SPI
+
+  // ESP32 pointers
+  esp_netif_t *eth_netif_{nullptr};
+  esp_eth_handle_t eth_handle_;
+  esp_eth_phy_t *phy_{nullptr};
+#endif  // USE_ESP32
+
+#ifdef USE_RP2
+  static constexpr uint32_t LINK_CHECK_INTERVAL = 500;  // ms between link/IP polls
+#if defined(USE_ETHERNET_W5100)
+  static constexpr uint32_t RESET_DELAY_MS = 150;  // W5100S PLL lock time
+#elif defined(USE_ETHERNET_W6300)
+  static constexpr uint32_t RESET_DELAY_MS = 100;  // W6300 needs 100ms after hardware reset
+#else
+  static constexpr uint32_t RESET_DELAY_MS = 10;
+#endif
+#if defined(USE_ETHERNET_W5500)
+  Wiznet5500lwIP *eth_{nullptr};
+#elif defined(USE_ETHERNET_W5100)
+  Wiznet5100lwIP *eth_{nullptr};
+#elif defined(USE_ETHERNET_W6100)
+  Wiznet6100lwIP *eth_{nullptr};
+#elif defined(USE_ETHERNET_W6300)
+  Wiznet6300lwIPFixed *eth_{nullptr};
+#elif defined(USE_ETHERNET_ENC28J60)
+  ENC28J60lwIP *eth_{nullptr};
+#else
+#error "Unsupported RP2040 SPI Ethernet type"
+#endif
+  uint32_t last_link_check_{0};
+  uint8_t clk_pin_;
+  uint8_t miso_pin_;
+  uint8_t mosi_pin_;
+  uint8_t cs_pin_;
+  int8_t interrupt_pin_{-1};
+  int8_t reset_pin_{-1};
+#endif  // USE_RP2
+
+  // Common members
+#ifdef USE_ETHERNET_MANUAL_IP
+  optional<ManualIP> manual_ip_{};
+#endif
+  uint32_t connect_begin_;
+
+  // Group all uint8_t types together (enums and bools)
+  EthernetType type_{ETHERNET_TYPE_UNKNOWN};
+  EthernetComponentState state_{EthernetComponentState::STOPPED};
+  bool started_{false};
+  bool connected_{false};
+  bool got_ipv4_address_{false};
+  // Codegen-time YAML option. When false, setup() defers esp_eth_start().
+  bool enable_on_boot_{true};
+  // Mirror of "is the link intentionally stopped" — set when setup() honors
+  // enable_on_boot=false, cleared by enable(), set again by disable().
+  bool disabled_{false};
+#ifdef USE_ESP32
+  // Tracks whether ethernet_lazy_init_() has completed successfully. Allows enable()
+  // to be called at runtime after enable_on_boot:false without re-allocating, and
+  // ensures setup() skips the heavy init when enable_on_boot_ is false.
+  bool ethernet_initialized_{false};
+#endif
+#if LWIP_IPV6
+  uint8_t ipv6_count_{0};
+  bool ipv6_setup_done_{false};
+#endif /* LWIP_IPV6 */
+
+  optional<std::array<uint8_t, 6>> fixed_mac_;
+
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+  StaticVector<EthernetIPStateListener *, ESPHOME_ETHERNET_IP_STATE_LISTENERS> ip_state_listeners_;
+#endif
+
+#ifdef USE_ETHERNET_CONNECT_TRIGGER
+  Trigger<> connect_trigger_;
+#endif
+#ifdef USE_ETHERNET_DISCONNECT_TRIGGER
+  Trigger<> disconnect_trigger_;
+#endif
+ private:
+  // Stores a pointer to a string literal (static storage duration).
+  // ONLY set from Python-generated code with string literals - never dynamic strings.
+  const char *use_address_{nullptr};
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern EthernetComponent *global_eth_component;
+
+#ifdef USE_ESP32
+#if defined(USE_ETHERNET_JL1101) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0) || \
+                                     ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 2) || !defined(PLATFORMIO))
+extern "C" esp_eth_phy_t *esp_eth_phy_new_jl1101(const eth_phy_config_t *config);
+#endif
+#endif  // USE_ESP32
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ETHERNET

--- a/ch390/components/ethernet/ethernet_component_esp32.cpp
+++ b/ch390/components/ethernet/ethernet_component_esp32.cpp
@@ -1,0 +1,1099 @@
+#include "ethernet_component.h"
+
+#if defined(USE_ETHERNET) && defined(USE_ESP32)
+
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "w5500_custom_spi.h"
+
+#include <lwip/dns.h>
+#include <cinttypes>
+#include "esp_event.h"
+
+// IDF 6.0 moved per-chip PHY/MAC drivers to the Espressif Component Registry;
+// they are no longer included via esp_eth.h and need explicit includes.
+// On IDF 5.x these headers don't exist as standalone files.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifdef USE_ETHERNET_LAN8720
+#include "esp_eth_phy_lan87xx.h"
+#endif
+#ifdef USE_ETHERNET_RTL8201
+#include "esp_eth_phy_rtl8201.h"
+#endif
+#ifdef USE_ETHERNET_DP83848
+#include "esp_eth_phy_dp83848.h"
+#endif
+#ifdef USE_ETHERNET_IP101
+#include "esp_eth_phy_ip101.h"
+#endif
+#ifdef USE_ETHERNET_KSZ8081
+#include "esp_eth_phy_ksz80xx.h"
+#endif
+#ifdef USE_ETHERNET_W5500
+#include "esp_eth_mac_w5500.h"
+#include "esp_eth_phy_w5500.h"
+#endif
+#ifdef USE_ETHERNET_DM9051
+#include "esp_eth_mac_dm9051.h"
+#include "esp_eth_phy_dm9051.h"
+#endif
+#endif  // ESP_IDF_VERSION >= 6.0.0
+
+// LAN867x header exists on all IDF versions (external component since IDF 5.3)
+#ifdef USE_ETHERNET_LAN8670
+#include "esp_eth_phy_lan867x.h"
+#endif
+
+// ENC28J60 header exists on all IDF versions (always an external component)
+#ifdef USE_ETHERNET_ENC28J60
+#include "esp_eth_enc28j60.h"
+#endif
+
+// CH390 headers exist on all IDF versions (always an external component)
+#ifdef USE_ETHERNET_CH390
+#include "esp_eth_mac_ch390.h"
+#include "esp_eth_phy_ch390.h"
+#endif
+
+#ifdef USE_ETHERNET_SPI
+#include <driver/gpio.h>
+#include <driver/spi_master.h>
+#endif
+
+namespace esphome::ethernet {
+
+static const char *const TAG = "ethernet";
+
+// PHY register size for hex logging
+static constexpr size_t PHY_REG_SIZE = 2;
+
+void EthernetComponent::log_error_and_mark_failed_(esp_err_t err, const char *message) {
+  ESP_LOGE(TAG, "%s: (%d) %s", message, err, esp_err_to_name(err));
+  this->mark_failed();
+}
+
+#define ESPHL_ERROR_CHECK(err, message) \
+  if ((err) != ESP_OK) { \
+    this->log_error_and_mark_failed_(err, message); \
+    return; \
+  }
+
+#define ESPHL_ERROR_CHECK_RET(err, message, ret) \
+  if ((err) != ESP_OK) { \
+    this->log_error_and_mark_failed_(err, message); \
+    return ret; \
+  }
+
+void EthernetComponent::loop() {
+  const uint32_t now = App.get_loop_component_start_time();
+
+  switch (this->state_) {
+    case EthernetComponentState::STOPPED:
+      if (this->started_) {
+        ESP_LOGI(TAG, "Starting connection");
+        this->state_ = EthernetComponentState::CONNECTING;
+        this->start_connect_();
+      }
+      break;
+    case EthernetComponentState::CONNECTING:
+      if (!this->started_) {
+        ESP_LOGI(TAG, "Stopped connection");
+        this->state_ = EthernetComponentState::STOPPED;
+      } else if (this->connected_) {
+        // connection established
+        ESP_LOGI(TAG, "Connected");
+        this->state_ = EthernetComponentState::CONNECTED;
+
+        this->dump_connect_params_();
+        this->status_clear_warning();
+#ifdef USE_ETHERNET_CONNECT_TRIGGER
+        this->connect_trigger_.trigger();
+#endif
+      } else if (now - this->connect_begin_ > 15000) {
+        ESP_LOGW(TAG, "Connecting failed; reconnecting");
+        this->start_connect_();
+      }
+      break;
+    case EthernetComponentState::CONNECTED:
+      if (!this->started_) {
+        ESP_LOGI(TAG, "Stopped connection");
+        this->state_ = EthernetComponentState::STOPPED;
+#ifdef USE_ETHERNET_DISCONNECT_TRIGGER
+        this->disconnect_trigger_.trigger();
+#endif
+      } else if (!this->connected_) {
+        ESP_LOGW(TAG, "Connection lost; reconnecting");
+        this->state_ = EthernetComponentState::CONNECTING;
+        this->start_connect_();
+#ifdef USE_ETHERNET_DISCONNECT_TRIGGER
+        this->disconnect_trigger_.trigger();
+#endif
+      } else {
+        this->finish_connect_();
+        // When connected and stable, disable the loop to save CPU cycles
+        this->disable_loop();
+      }
+      break;
+  }
+}
+
+void EthernetComponent::setup() {
+  if (esp_reset_reason() != ESP_RST_DEEPSLEEP) {
+    // Delay here to allow power to stabilise before Ethernet is initialized.
+    delay(300);  // NOLINT
+  }
+
+  if (this->enable_on_boot_) {
+    this->ethernet_lazy_init_();
+    if (!this->ethernet_initialized_) {
+      // lazy_init bailed early via ESPHL_ERROR_CHECK or mark_failed; nothing more to do.
+      return;
+    }
+    esp_err_t err = esp_eth_start(this->eth_handle_);
+    ESPHL_ERROR_CHECK(err, "ETH start error");
+  } else {
+    ESP_LOGCONFIG(TAG, "Skipping init (enable_on_boot: false)");
+    this->disabled_ = true;
+  }
+}
+
+void EthernetComponent::ethernet_lazy_init_() {
+  if (this->ethernet_initialized_)
+    return;
+
+  esp_err_t err;
+
+#ifdef USE_ETHERNET_SPI
+  // Install GPIO ISR handler to be able to service SPI Eth modules interrupts
+  gpio_install_isr_service(0);
+
+  spi_bus_config_t buscfg = {
+      .mosi_io_num = this->mosi_pin_,
+      .miso_io_num = this->miso_pin_,
+      .sclk_io_num = this->clk_pin_,
+      .quadwp_io_num = -1,
+      .quadhd_io_num = -1,
+      .data4_io_num = -1,
+      .data5_io_num = -1,
+      .data6_io_num = -1,
+      .data7_io_num = -1,
+      .max_transfer_sz = 0,
+      .flags = 0,
+      .intr_flags = 0,
+  };
+
+  auto host = this->interface_;
+
+  err = spi_bus_initialize(host, &buscfg, SPI_DMA_CH_AUTO);
+  ESPHL_ERROR_CHECK(err, "SPI bus initialize error");
+#endif
+  // Network interface setup handled by network component
+
+  esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
+  this->eth_netif_ = esp_netif_new(&cfg);
+
+  // Init MAC and PHY configs to default
+  eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+  eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+
+#ifdef USE_ETHERNET_SPI  // Configure SPI interface and Ethernet driver for specific SPI module
+  spi_device_interface_config_t devcfg = {
+      .command_bits = 0,
+      .address_bits = 0,
+      .dummy_bits = 0,
+      .mode = 0,
+      .duty_cycle_pos = 0,
+      .cs_ena_pretrans = 0,
+      .cs_ena_posttrans = 0,
+      .clock_speed_hz = this->clock_speed_,
+      .input_delay_ns = 0,
+      .spics_io_num = this->cs_pin_,
+      .flags = 0,
+      .queue_size = 20,
+      .pre_cb = nullptr,
+      .post_cb = nullptr,
+  };
+
+#if defined(USE_ETHERNET_W5500)
+  eth_w5500_config_t w5500_config = ETH_W5500_DEFAULT_CONFIG(host, &devcfg);
+#elif defined(USE_ETHERNET_DM9051)
+  eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(host, &devcfg);
+#elif defined(USE_ETHERNET_ENC28J60)
+  eth_enc28j60_config_t enc28j60_config = ETH_ENC28J60_DEFAULT_CONFIG(host, &devcfg);
+#elif defined(USE_ETHERNET_CH390)
+  eth_ch390_config_t ch390_config = ETH_CH390_DEFAULT_CONFIG(host, &devcfg);
+#endif
+
+#if defined(USE_ETHERNET_W5500)
+  w5500_config.int_gpio_num = this->interrupt_pin_;
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+  w5500_config.poll_period_ms = this->polling_interval_;
+#endif
+  // Install the custom SPI driver that offloads the bulk RX/TX frame transfers off the busy-wait
+  // path. w5500_config (and the devcfg it references) outlives esp_eth_mac_new_w5500() below, which
+  // runs the driver's init().
+  install_w5500_async_spi(w5500_config);
+#elif defined(USE_ETHERNET_DM9051)
+  dm9051_config.int_gpio_num = this->interrupt_pin_;
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+  dm9051_config.poll_period_ms = this->polling_interval_;
+#endif
+#elif defined(USE_ETHERNET_ENC28J60)
+  // ENC28J60 does not support poll_period_ms. CS must stay asserted for the chip's CS hold
+  // time (t10, 210 ns) after the last clock or MAC/MII register reads fail ("wrong chip ID")
+  enc28j60_config.spi_devcfg->cs_ena_posttrans = enc28j60_cal_spi_cs_hold_time((this->clock_speed_ + 999999) / 1000000);
+  enc28j60_config.int_gpio_num = this->interrupt_pin_;
+#elif defined(USE_ETHERNET_CH390)
+  ch390_config.int_gpio_num = this->interrupt_pin_;
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+  ch390_config.poll_period_ms = this->polling_interval_;
+#endif
+#endif
+
+  phy_config.phy_addr = this->phy_addr_spi_;
+  phy_config.reset_gpio_num = this->reset_pin_;
+
+  esp_eth_mac_t *mac = nullptr;
+#elif defined(USE_ETHERNET_OPENETH)
+  esp_eth_mac_t *mac = esp_eth_mac_new_openeth(&mac_config);
+#else
+  phy_config.phy_addr = this->phy_addr_;
+  phy_config.reset_gpio_num = this->power_pin_;
+
+  eth_esp32_emac_config_t esp32_emac_config = eth_esp32_emac_default_config();
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+  esp32_emac_config.smi_gpio.mdc_num = this->mdc_pin_;
+  esp32_emac_config.smi_gpio.mdio_num = this->mdio_pin_;
+#else
+  esp32_emac_config.smi_mdc_gpio_num = this->mdc_pin_;
+  esp32_emac_config.smi_mdio_gpio_num = this->mdio_pin_;
+#endif
+  // The RGMII types (GENERIC, YT8531) use the RGMII interface and default GPIO map from
+  // eth_esp32_emac_default_config(); writing the RMII clock config would clobber that
+  // union, so skip the RMII clock override for them.
+  if (this->type_ != ETHERNET_TYPE_GENERIC && this->type_ != ETHERNET_TYPE_YT8531) {
+    esp32_emac_config.clock_config.rmii.clock_mode = this->clk_mode_;
+    esp32_emac_config.clock_config.rmii.clock_gpio =
+        static_cast<decltype(esp32_emac_config.clock_config.rmii.clock_gpio)>(this->clk_pin_);
+  }
+
+  esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+#endif
+
+  switch (this->type_) {
+#ifdef USE_ETHERNET_OPENETH
+    case ETHERNET_TYPE_OPENETH: {
+      phy_config.autonego_timeout_ms = 1000;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+      this->phy_ = esp_eth_phy_new_generic(&phy_config);
+#else
+      this->phy_ = esp_eth_phy_new_dp83848(&phy_config);
+#endif
+      break;
+    }
+#endif
+#if CONFIG_ETH_USE_ESP32_EMAC
+#ifdef USE_ETHERNET_LAN8720
+    case ETHERNET_TYPE_LAN8720: {
+      this->phy_ = esp_eth_phy_new_lan87xx(&phy_config);
+      break;
+    }
+#endif
+#ifdef USE_ETHERNET_RTL8201
+    case ETHERNET_TYPE_RTL8201: {
+      this->phy_ = esp_eth_phy_new_rtl8201(&phy_config);
+      break;
+    }
+#endif
+#ifdef USE_ETHERNET_DP83848
+    case ETHERNET_TYPE_DP83848: {
+      this->phy_ = esp_eth_phy_new_dp83848(&phy_config);
+      break;
+    }
+#endif
+#ifdef USE_ETHERNET_IP101
+    case ETHERNET_TYPE_IP101: {
+      this->phy_ = esp_eth_phy_new_ip101(&phy_config);
+      break;
+    }
+#endif
+#ifdef USE_ETHERNET_JL1101
+    case ETHERNET_TYPE_JL1101: {
+      // PlatformIO (pioarduino): builtin esp_eth_phy_new_jl1101() on all IDF versions
+      // Non-PlatformIO: custom ESPHome driver (esp_eth_phy_jl1101.c)
+      this->phy_ = esp_eth_phy_new_jl1101(&phy_config);
+      break;
+    }
+#endif
+#ifdef USE_ETHERNET_KSZ8081
+    case ETHERNET_TYPE_KSZ8081:
+    case ETHERNET_TYPE_KSZ8081RNA: {
+      this->phy_ = esp_eth_phy_new_ksz80xx(&phy_config);
+      break;
+    }
+#endif
+#ifdef USE_ETHERNET_LAN8670
+    case ETHERNET_TYPE_LAN8670: {
+      this->phy_ = esp_eth_phy_new_lan867x(&phy_config);
+      break;
+    }
+#endif
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    // GENERIC and YT8531 both use the built-in generic 802.3 PHY driver; YT8531 gets
+    // extra chip-specific tuning applied later in ethernet_lazy_init_().
+#ifdef USE_ETHERNET_GENERIC
+    case ETHERNET_TYPE_GENERIC:
+#endif
+#ifdef USE_ETHERNET_YT8531
+    case ETHERNET_TYPE_YT8531:
+#endif
+#if defined(USE_ETHERNET_GENERIC) || defined(USE_ETHERNET_YT8531)
+      this->phy_ = esp_eth_phy_new_generic(&phy_config);
+      break;
+#endif
+#endif
+#endif
+#ifdef USE_ETHERNET_SPI
+#if defined(USE_ETHERNET_W5500)
+    case ETHERNET_TYPE_W5500: {
+      mac = esp_eth_mac_new_w5500(&w5500_config, &mac_config);
+      this->phy_ = esp_eth_phy_new_w5500(&phy_config);
+      break;
+    }
+#elif defined(USE_ETHERNET_DM9051)
+    case ETHERNET_TYPE_DM9051: {
+      mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
+      this->phy_ = esp_eth_phy_new_dm9051(&phy_config);
+      break;
+    }
+#elif defined(USE_ETHERNET_ENC28J60)
+    case ETHERNET_TYPE_ENC28J60: {
+      mac = esp_eth_mac_new_enc28j60(&enc28j60_config, &mac_config);
+      this->phy_ = esp_eth_phy_new_enc28j60(&phy_config);
+      break;
+    }
+#elif defined(USE_ETHERNET_CH390)
+    case ETHERNET_TYPE_CH390: {
+      mac = esp_eth_mac_new_ch390(&ch390_config, &mac_config);
+      this->phy_ = esp_eth_phy_new_ch390(&phy_config);
+      break;
+    }
+#endif
+#endif
+    default: {
+      this->mark_failed();
+      return;
+    }
+  }
+
+  esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, this->phy_);
+  this->eth_handle_ = nullptr;
+  err = esp_eth_driver_install(&eth_config, &this->eth_handle_);
+  ESPHL_ERROR_CHECK(err, "ETH driver install error");
+
+#ifndef USE_ETHERNET_SPI
+#ifdef USE_ETHERNET_KSZ8081
+  if (this->type_ == ETHERNET_TYPE_KSZ8081RNA && this->clk_mode_ == EMAC_CLK_OUT) {
+    // KSZ8081RNA default is incorrect. It expects a 25MHz clock instead of the 50MHz we provide.
+    this->ksz8081_set_clock_reference_(mac);
+  }
+#endif  // USE_ETHERNET_KSZ8081
+
+  for (const auto &phy_register : this->phy_registers_) {
+    this->write_phy_register_(mac, phy_register);
+  }
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifdef USE_ETHERNET_GENERIC
+  // The generic 802.3 PHY driver only resets the PHY in its init; it never enables
+  // auto-negotiation. A PHY that resets into a forced-speed mode (BMCR auto-nego bit
+  // clear) therefore stays there, and esp_eth_start() skips negotiation because the
+  // driver cached auto_nego_en=false at install time. Force auto-negotiation on here
+  // (which also updates that cached state) so esp_eth_start() restarts a proper
+  // negotiation. (YT8531 does this as part of its own chip-specific init below.)
+  if (this->type_ == ETHERNET_TYPE_GENERIC) {
+    bool autoneg_enable = true;
+    err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_S_AUTONEGO, &autoneg_enable);
+    ESPHL_ERROR_CHECK(err, "Enable auto-negotiation failed");
+  }
+#endif
+#ifdef USE_ETHERNET_YT8531
+  if (this->type_ == ETHERNET_TYPE_YT8531) {
+    this->yt8531_phy_init_();
+    if (this->is_failed())
+      return;
+  }
+#endif
+#endif  // ESP_IDF_VERSION >= 6.0.0
+#endif  // !USE_ETHERNET_SPI
+
+  // use ESP internal eth mac
+  uint8_t mac_addr[6];
+  if (this->fixed_mac_.has_value()) {
+    memcpy(mac_addr, this->fixed_mac_->data(), 6);
+  } else {
+    esp_read_mac(mac_addr, ESP_MAC_ETH);
+  }
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_S_MAC_ADDR, mac_addr);
+  ESPHL_ERROR_CHECK(err, "set mac address error");
+
+  /* attach Ethernet driver to TCP/IP stack */
+  err = esp_netif_attach(this->eth_netif_, esp_eth_new_netif_glue(this->eth_handle_));
+  ESPHL_ERROR_CHECK(err, "ETH netif attach error");
+
+  // Register user defined event handers
+  err = esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &EthernetComponent::eth_event_handler, nullptr);
+  ESPHL_ERROR_CHECK(err, "ETH event handler register error");
+  err = esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &EthernetComponent::got_ip_event_handler, nullptr);
+  ESPHL_ERROR_CHECK(err, "GOT IP event handler register error");
+#if USE_NETWORK_IPV6
+  err = esp_event_handler_register(IP_EVENT, IP_EVENT_GOT_IP6, &EthernetComponent::got_ip6_event_handler, nullptr);
+  ESPHL_ERROR_CHECK(err, "GOT IPv6 event handler register error");
+#endif /* USE_NETWORK_IPV6 */
+
+  this->ethernet_initialized_ = true;
+}
+
+void EthernetComponent::enable() {
+  if (!this->disabled_)
+    return;
+
+  ESP_LOGD(TAG, "Enabling");
+  this->ethernet_lazy_init_();
+  if (!this->ethernet_initialized_) {
+    ESP_LOGE(TAG, "Cannot enable - init failed");
+    return;
+  }
+  esp_err_t err = esp_eth_start(this->eth_handle_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_eth_start failed: %s", esp_err_to_name(err));
+    return;
+  }
+  this->disabled_ = false;
+  // The ETH_EVENT_START handler will set started_=true; the loop state machine
+  // will then drive the STOPPED -> CONNECTING -> CONNECTED transitions.
+  this->enable_loop();
+}
+
+void EthernetComponent::disable() {
+  if (this->disabled_)
+    return;
+
+  ESP_LOGD(TAG, "Disabling");
+  esp_err_t err = esp_eth_stop(this->eth_handle_);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "esp_eth_stop failed: %s — disabling anyway", esp_err_to_name(err));
+  }
+  this->disabled_ = true;
+  // ETH_EVENT_STOP will clear started_; loop() will transition to STOPPED.
+}
+
+void EthernetComponent::dump_config() {
+  const char *eth_type;
+  switch (this->type_) {
+#ifdef USE_ETHERNET_LAN8720
+    case ETHERNET_TYPE_LAN8720:
+      eth_type = "LAN8720";
+      break;
+#endif
+#ifdef USE_ETHERNET_RTL8201
+    case ETHERNET_TYPE_RTL8201:
+      eth_type = "RTL8201";
+      break;
+#endif
+#ifdef USE_ETHERNET_DP83848
+    case ETHERNET_TYPE_DP83848:
+      eth_type = "DP83848";
+      break;
+#endif
+#ifdef USE_ETHERNET_IP101
+    case ETHERNET_TYPE_IP101:
+      eth_type = "IP101";
+      break;
+#endif
+#ifdef USE_ETHERNET_JL1101
+    case ETHERNET_TYPE_JL1101:
+      eth_type = "JL1101";
+      break;
+#endif
+#ifdef USE_ETHERNET_KSZ8081
+    case ETHERNET_TYPE_KSZ8081:
+      eth_type = "KSZ8081";
+      break;
+
+    case ETHERNET_TYPE_KSZ8081RNA:
+      eth_type = "KSZ8081RNA";
+      break;
+#endif
+#if defined(USE_ETHERNET_W5500)
+    case ETHERNET_TYPE_W5500:
+      eth_type = "W5500";
+      break;
+#elif defined(USE_ETHERNET_DM9051)
+    case ETHERNET_TYPE_DM9051:
+      eth_type = "DM9051";
+      break;
+#elif defined(USE_ETHERNET_ENC28J60)
+    case ETHERNET_TYPE_ENC28J60:
+      eth_type = "ENC28J60";
+      break;
+#elif defined(USE_ETHERNET_CH390)
+    case ETHERNET_TYPE_CH390:
+      eth_type = "CH390";
+      break;
+#endif
+#ifdef USE_ETHERNET_OPENETH
+    case ETHERNET_TYPE_OPENETH:
+      eth_type = "OPENETH";
+      break;
+#endif
+#ifdef USE_ETHERNET_LAN8670
+    case ETHERNET_TYPE_LAN8670:
+      eth_type = "LAN8670";
+      break;
+#endif
+#ifdef USE_ETHERNET_GENERIC
+    case ETHERNET_TYPE_GENERIC:
+      eth_type = "Generic (RGMII)";
+      break;
+#endif
+#ifdef USE_ETHERNET_YT8531
+    case ETHERNET_TYPE_YT8531:
+      eth_type = "YT8531 (RGMII)";
+      break;
+#endif
+
+    default:
+      eth_type = "Unknown";
+      break;
+  }
+
+  ESP_LOGCONFIG(TAG,
+                "Ethernet:\n"
+                "  Connected: %s",
+                YESNO(this->is_connected()));
+  this->dump_connect_params_();
+#ifdef USE_ETHERNET_SPI
+  ESP_LOGCONFIG(TAG,
+                "  CLK Pin: %u\n"
+                "  MISO Pin: %u\n"
+                "  MOSI Pin: %u\n"
+                "  CS Pin: %u",
+                this->clk_pin_, this->miso_pin_, this->mosi_pin_, this->cs_pin_);
+  const char *spi_interface = "spi3";
+  if (this->interface_ == SPI2_HOST) {
+    spi_interface = "spi2";
+  }
+  ESP_LOGCONFIG(TAG, "  Interface: %s", spi_interface);
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+  if (this->polling_interval_ != 0) {
+    ESP_LOGCONFIG(TAG, "  Polling Interval: %" PRIu32 " ms", this->polling_interval_);
+  } else
+#endif
+  {
+    ESP_LOGCONFIG(TAG, "  IRQ Pin: %d", this->interrupt_pin_);
+  }
+  ESP_LOGCONFIG(TAG,
+                "  Reset Pin: %d\n"
+                "  Clock Speed: %d MHz",
+                this->reset_pin_, this->clock_speed_ / 1000000);
+#else
+  if (this->power_pin_ != -1) {
+    ESP_LOGCONFIG(TAG, "  Power Pin: %u", this->power_pin_);
+  }
+  ESP_LOGCONFIG(TAG,
+                "  CLK Pin: %u\n"
+                "  MDC Pin: %u\n"
+                "  MDIO Pin: %u\n"
+                "  PHY addr: %u",
+                this->clk_pin_, this->mdc_pin_, this->mdio_pin_, this->phy_addr_);
+#endif
+  ESP_LOGCONFIG(TAG, "  Type: %s", eth_type);
+}
+
+network::IPAddresses EthernetComponent::get_ip_addresses() {
+  network::IPAddresses addresses;
+  if (!this->ethernet_initialized_)
+    return addresses;  // all-zero IPs
+  esp_netif_ip_info_t ip;
+  esp_err_t err = esp_netif_get_ip_info(this->eth_netif_, &ip);
+  if (err != ESP_OK) {
+    ESP_LOGV(TAG, "esp_netif_get_ip_info failed: %s", esp_err_to_name(err));
+    // TODO: do something smarter
+    // return false;
+  } else {
+    addresses[0] = network::IPAddress(&ip.ip);
+  }
+#if USE_NETWORK_IPV6
+  struct esp_ip6_addr if_ip6s[CONFIG_LWIP_IPV6_NUM_ADDRESSES];
+  uint8_t count = 0;
+  count = esp_netif_get_all_ip6(this->eth_netif_, if_ip6s);
+  assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
+  assert(count < addresses.size());
+  for (int i = 0; i < count; i++) {
+    addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
+  }
+#endif /* USE_NETWORK_IPV6 */
+
+  return addresses;
+}
+
+network::IPAddress EthernetComponent::get_dns_address(uint8_t num) {
+  LwIPLock lock;
+  const ip_addr_t *dns_ip = dns_getserver(num);
+  return dns_ip;
+}
+
+void EthernetComponent::eth_event_handler(void *arg, esp_event_base_t event_base, int32_t event, void *event_data) {
+  const char *event_name;
+
+  switch (event) {
+    case ETHERNET_EVENT_START:
+      event_name = "ETH started";
+      global_eth_component->started_ = true;
+      global_eth_component->enable_loop_soon_any_context();
+      break;
+    case ETHERNET_EVENT_STOP:
+      event_name = "ETH stopped";
+      global_eth_component->started_ = false;
+      global_eth_component->connected_ = false;
+      global_eth_component->enable_loop_soon_any_context();  // Enable loop when connection state changes
+      break;
+    case ETHERNET_EVENT_CONNECTED:
+      event_name = "ETH connected";
+      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
+#if defined(USE_ETHERNET_IP_STATE_LISTENERS) && defined(USE_ETHERNET_MANUAL_IP)
+      if (global_eth_component->manual_ip_.has_value()) {
+        global_eth_component->notify_ip_state_listeners_();
+      }
+#endif
+      break;
+    case ETHERNET_EVENT_DISCONNECTED:
+      event_name = "ETH disconnected";
+      global_eth_component->connected_ = false;
+      global_eth_component->enable_loop_soon_any_context();  // Enable loop when connection state changes
+      break;
+    default:
+      return;
+  }
+
+  ESP_LOGV(TAG, "[Ethernet event] %s (num=%" PRId32 ")", event_name, event);
+}
+
+void EthernetComponent::got_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
+                                             void *event_data) {
+  ip_event_got_ip_t *event = (ip_event_got_ip_t *) event_data;
+  const esp_netif_ip_info_t *ip_info = &event->ip_info;
+  ESP_LOGV(TAG, "[Ethernet event] ETH Got IP " IPSTR, IP2STR(&ip_info->ip));
+  global_eth_component->got_ipv4_address_ = true;
+#if USE_NETWORK_IPV6 && (USE_NETWORK_MIN_IPV6_ADDR_COUNT > 0)
+  global_eth_component->connected_ = global_eth_component->ipv6_count_ >= USE_NETWORK_MIN_IPV6_ADDR_COUNT;
+  global_eth_component->enable_loop_soon_any_context();  // Enable loop when connection state changes
+#else
+  global_eth_component->connected_ = true;
+  global_eth_component->enable_loop_soon_any_context();  // Enable loop when connection state changes
+#endif /* USE_NETWORK_IPV6 */
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+  global_eth_component->notify_ip_state_listeners_();
+#endif
+}
+
+#if USE_NETWORK_IPV6
+void EthernetComponent::got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
+                                              void *event_data) {
+  ip_event_got_ip6_t *event = (ip_event_got_ip6_t *) event_data;
+  ESP_LOGV(TAG, "[Ethernet event] ETH Got IPv6: " IPV6STR, IPV62STR(event->ip6_info.ip));
+  global_eth_component->ipv6_count_ += 1;
+#if (USE_NETWORK_MIN_IPV6_ADDR_COUNT > 0)
+  global_eth_component->connected_ =
+      global_eth_component->got_ipv4_address_ && (global_eth_component->ipv6_count_ >= USE_NETWORK_MIN_IPV6_ADDR_COUNT);
+  global_eth_component->enable_loop_soon_any_context();  // Enable loop when connection state changes
+#else
+  global_eth_component->connected_ = global_eth_component->got_ipv4_address_;
+  global_eth_component->enable_loop_soon_any_context();  // Enable loop when connection state changes
+#endif
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+  global_eth_component->notify_ip_state_listeners_();
+#endif
+}
+#endif /* USE_NETWORK_IPV6 */
+
+void EthernetComponent::finish_connect_() {
+#if USE_NETWORK_IPV6
+  // Retry IPv6 link-local setup if it failed during initial connect
+  // This handles the case where min_ipv6_addr_count is NOT set (or is 0),
+  // allowing us to reach CONNECTED state with just IPv4.
+  // If IPv6 setup failed in start_connect_() because the interface wasn't ready:
+  // - Bootup timing issues (#10281)
+  // - Cable unplugged/network interruption (#10705)
+  // We can now retry since we're in CONNECTED state and the interface is definitely up.
+  if (!this->ipv6_setup_done_) {
+    esp_err_t err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+    if (err == ESP_OK) {
+      ESP_LOGD(TAG, "IPv6 link-local address created (retry succeeded)");
+    }
+    // Always set the flag to prevent continuous retries
+    // If IPv6 setup fails here with the interface up and stable, it's
+    // likely a persistent issue (IPv6 disabled at router, hardware
+    // limitation, etc.) that won't be resolved by further retries.
+    // The device continues to work with IPv4.
+    this->ipv6_setup_done_ = true;
+  }
+#endif /* USE_NETWORK_IPV6 */
+}
+
+void EthernetComponent::start_connect_() {
+  global_eth_component->got_ipv4_address_ = false;
+#if USE_NETWORK_IPV6
+  global_eth_component->ipv6_count_ = 0;
+  this->ipv6_setup_done_ = false;
+#endif /* USE_NETWORK_IPV6 */
+  this->connect_begin_ = millis();
+  this->status_set_warning(LOG_STR("waiting for IP configuration"));
+
+  esp_err_t err;
+  err = esp_netif_set_hostname(this->eth_netif_, App.get_name().c_str());
+  if (err != ERR_OK) {
+    ESP_LOGW(TAG, "esp_netif_set_hostname failed: %s", esp_err_to_name(err));
+  }
+
+  esp_netif_ip_info_t info;
+#ifdef USE_ETHERNET_MANUAL_IP
+  if (this->manual_ip_.has_value()) {
+    info.ip = this->manual_ip_->static_ip;
+    info.gw = this->manual_ip_->gateway;
+    info.netmask = this->manual_ip_->subnet;
+  } else
+#endif
+  {
+    info.ip.addr = 0;
+    info.gw.addr = 0;
+    info.netmask.addr = 0;
+  }
+
+  esp_netif_dhcp_status_t status = ESP_NETIF_DHCP_INIT;
+
+  err = esp_netif_dhcpc_get_status(this->eth_netif_, &status);
+  ESPHL_ERROR_CHECK(err, "DHCPC Get Status Failed!");
+
+  ESP_LOGV(TAG, "DHCP Client Status: %d", status);
+
+  err = esp_netif_dhcpc_stop(this->eth_netif_);
+  if (err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STOPPED) {
+    ESPHL_ERROR_CHECK(err, "DHCPC stop error");
+  }
+
+  err = esp_netif_set_ip_info(this->eth_netif_, &info);
+  ESPHL_ERROR_CHECK(err, "DHCPC set IP info error");
+
+#ifdef USE_ETHERNET_MANUAL_IP
+  if (this->manual_ip_.has_value()) {
+    LwIPLock lock;
+    if (this->manual_ip_->dns1.is_set()) {
+      ip_addr_t d;
+      d = this->manual_ip_->dns1;
+      dns_setserver(0, &d);
+    }
+    if (this->manual_ip_->dns2.is_set()) {
+      ip_addr_t d;
+      d = this->manual_ip_->dns2;
+      dns_setserver(1, &d);
+    }
+  } else
+#endif
+  {
+    err = esp_netif_dhcpc_start(this->eth_netif_);
+    if (err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STARTED) {
+      ESPHL_ERROR_CHECK(err, "DHCPC start error");
+    }
+  }
+#if USE_NETWORK_IPV6
+  // Attempt to create IPv6 link-local address
+  // We MUST attempt this here, not just in finish_connect_(), because with
+  // min_ipv6_addr_count set, the component won't reach CONNECTED state without IPv6.
+  // However, this may fail with ESP_FAIL if the interface is not up yet:
+  // - At bootup when link isn't ready (#10281)
+  // - After disconnection/cable unplugged (#10705)
+  // We'll retry in finish_connect_() if it fails here.
+  err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+  if (err != ESP_OK) {
+    if (err == ESP_ERR_ESP_NETIF_INVALID_PARAMS) {
+      // This is a programming error, not a transient failure
+      ESPHL_ERROR_CHECK(err, "esp_netif_create_ip6_linklocal invalid parameters");
+    } else {
+      // ESP_FAIL means the interface isn't up yet
+      // This is expected and non-fatal, happens in multiple scenarios:
+      // - During reconnection after network interruptions (#10705)
+      // - At bootup when the link isn't ready yet (#10281)
+      // We'll retry once we reach CONNECTED state and the interface is up
+      ESP_LOGW(TAG, "esp_netif_create_ip6_linklocal failed: %s", esp_err_to_name(err));
+      // Don't mark component as failed - this is a transient error
+    }
+  }
+#endif /* USE_NETWORK_IPV6 */
+
+  this->connect_begin_ = millis();
+  this->status_set_warning();
+}
+
+void EthernetComponent::dump_connect_params_() {
+  if (!this->ethernet_initialized_) {
+    ESP_LOGCONFIG(TAG, "  uninitialized/disabled");
+    return;
+  }
+  esp_netif_ip_info_t ip;
+  esp_netif_get_ip_info(this->eth_netif_, &ip);
+  const ip_addr_t *dns_ip1;
+  const ip_addr_t *dns_ip2;
+  {
+    LwIPLock lock;
+    dns_ip1 = dns_getserver(0);
+    dns_ip2 = dns_getserver(1);
+  }
+
+  // Use stack buffers for IP address formatting to avoid heap allocations
+  char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char subnet_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char gateway_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char dns1_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char dns2_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  uint16_t link_speed = 10;
+  switch (this->get_link_speed()) {
+    case ETH_SPEED_100M:
+      link_speed = 100;
+      break;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
+    case ETH_SPEED_1000M:
+      link_speed = 1000;
+      break;
+#endif
+    default:
+      break;
+  }
+  ESP_LOGCONFIG(TAG,
+                "  IP Address: %s\n"
+                "  Hostname: '%s'\n"
+                "  Subnet: %s\n"
+                "  Gateway: %s\n"
+                "  DNS1: %s\n"
+                "  DNS2: %s\n"
+                "  MAC Address: %s\n"
+                "  Is Full Duplex: %s\n"
+                "  Link Speed: %u",
+                network::IPAddress(&ip.ip).str_to(ip_buf), App.get_name().c_str(),
+                network::IPAddress(&ip.netmask).str_to(subnet_buf), network::IPAddress(&ip.gw).str_to(gateway_buf),
+                network::IPAddress(dns_ip1).str_to(dns1_buf), network::IPAddress(dns_ip2).str_to(dns2_buf),
+                this->get_eth_mac_address_pretty_into_buffer(mac_buf),
+                YESNO(this->get_duplex_mode() == ETH_DUPLEX_FULL), link_speed);
+
+#if USE_NETWORK_IPV6
+  struct esp_ip6_addr if_ip6s[CONFIG_LWIP_IPV6_NUM_ADDRESSES];
+  uint8_t count = 0;
+  count = esp_netif_get_all_ip6(this->eth_netif_, if_ip6s);
+  assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
+  for (int i = 0; i < count; i++) {
+    ESP_LOGCONFIG(TAG, "  IPv6: " IPV6STR, IPV62STR(if_ip6s[i]));
+  }
+#endif /* USE_NETWORK_IPV6 */
+}
+
+#ifdef USE_ETHERNET_SPI
+void EthernetComponent::set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
+void EthernetComponent::set_miso_pin(uint8_t miso_pin) { this->miso_pin_ = miso_pin; }
+void EthernetComponent::set_mosi_pin(uint8_t mosi_pin) { this->mosi_pin_ = mosi_pin; }
+void EthernetComponent::set_cs_pin(uint8_t cs_pin) { this->cs_pin_ = cs_pin; }
+void EthernetComponent::set_interrupt_pin(uint8_t interrupt_pin) { this->interrupt_pin_ = interrupt_pin; }
+void EthernetComponent::set_reset_pin(uint8_t reset_pin) { this->reset_pin_ = reset_pin; }
+void EthernetComponent::set_clock_speed(int clock_speed) { this->clock_speed_ = clock_speed; }
+void EthernetComponent::set_interface(spi_host_device_t interface) { this->interface_ = interface; }
+#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
+void EthernetComponent::set_polling_interval(uint32_t polling_interval) { this->polling_interval_ = polling_interval; }
+#endif
+#else
+void EthernetComponent::set_phy_addr(uint8_t phy_addr) { this->phy_addr_ = phy_addr; }
+void EthernetComponent::set_power_pin(int power_pin) { this->power_pin_ = power_pin; }
+void EthernetComponent::set_mdc_pin(uint8_t mdc_pin) { this->mdc_pin_ = mdc_pin; }
+void EthernetComponent::set_mdio_pin(uint8_t mdio_pin) { this->mdio_pin_ = mdio_pin; }
+void EthernetComponent::set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
+void EthernetComponent::set_clk_mode(emac_rmii_clock_mode_t clk_mode) { this->clk_mode_ = clk_mode; }
+void EthernetComponent::add_phy_register(PHYRegister register_value) { this->phy_registers_.push_back(register_value); }
+#endif
+
+void EthernetComponent::get_eth_mac_address_raw(uint8_t *mac) {
+  if (!this->ethernet_initialized_) {
+    // External callers (mdns, ethernet_info, etc.) may ask for the MAC before/regardless
+    // of whether ethernet is enabled. Use the configured MAC if set, else the system ETH MAC.
+    if (this->fixed_mac_.has_value()) {
+      memcpy(mac, this->fixed_mac_->data(), 6);
+    } else {
+      esp_read_mac(mac, ESP_MAC_ETH);
+    }
+    return;
+  }
+  esp_err_t err;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_G_MAC_ADDR, mac);
+  ESPHL_ERROR_CHECK(err, "ETH_CMD_G_MAC error");
+}
+
+std::string EthernetComponent::get_eth_mac_address_pretty() {
+  char buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  return std::string(this->get_eth_mac_address_pretty_into_buffer(buf));
+}
+
+const char *EthernetComponent::get_eth_mac_address_pretty_into_buffer(
+    std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf) {
+  uint8_t mac[6];
+  get_eth_mac_address_raw(mac);
+  format_mac_addr_upper(mac, buf.data());
+  return buf.data();
+}
+
+eth_duplex_t EthernetComponent::get_duplex_mode() {
+  if (!this->ethernet_initialized_)
+    return ETH_DUPLEX_HALF;
+  esp_err_t err;
+  eth_duplex_t duplex_mode;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_G_DUPLEX_MODE, &duplex_mode);
+  ESPHL_ERROR_CHECK_RET(err, "ETH_CMD_G_DUPLEX_MODE error", ETH_DUPLEX_HALF);
+  return duplex_mode;
+}
+
+eth_speed_t EthernetComponent::get_link_speed() {
+  if (!this->ethernet_initialized_)
+    return ETH_SPEED_10M;
+  esp_err_t err;
+  eth_speed_t speed;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_G_SPEED, &speed);
+  ESPHL_ERROR_CHECK_RET(err, "ETH_CMD_G_SPEED error", ETH_SPEED_10M);
+  return speed;
+}
+
+bool EthernetComponent::powerdown() {
+  ESP_LOGI(TAG, "Powering down ethernet PHY");
+  if (this->phy_ == nullptr) {
+    ESP_LOGE(TAG, "Ethernet PHY not assigned");
+    return false;
+  }
+  this->connected_ = false;
+  this->started_ = false;
+  // No need to enable_loop() here as this is only called during shutdown/reboot
+  if (this->phy_->pwrctl(this->phy_, false) != ESP_OK) {
+    ESP_LOGE(TAG, "Error powering down ethernet PHY");
+    return false;
+  }
+  return true;
+}
+
+#ifndef USE_ETHERNET_SPI
+
+#ifdef USE_ETHERNET_KSZ8081
+constexpr uint8_t KSZ80XX_PC2R_REG_ADDR = 0x1F;
+
+void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
+  esp_err_t err;
+
+  uint32_t phy_control_2;
+  err = mac->read_phy_reg(mac, this->phy_addr_, KSZ80XX_PC2R_REG_ADDR, &(phy_control_2));
+  ESPHL_ERROR_CHECK(err, "Read PHY Control 2 failed");
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  char hex_buf[format_hex_pretty_size(PHY_REG_SIZE)];
+#endif
+  ESP_LOGVV(TAG, "KSZ8081 PHY Control 2: %s", format_hex_pretty_to(hex_buf, (uint8_t *) &phy_control_2, PHY_REG_SIZE));
+
+  /*
+   * Bit 7 is `RMII Reference Clock Select`. Default is `0`.
+   * KSZ8081RNA:
+   *   0 - clock input to XI (Pin 8) is 25 MHz for RMII - 25 MHz clock mode.
+   *   1 - clock input to XI (Pin 8) is 50 MHz for RMII - 50 MHz clock mode.
+   * KSZ8081RND:
+   *   0 - clock input to XI (Pin 8) is 50 MHz for RMII - 50 MHz clock mode.
+   *   1 - clock input to XI (Pin 8) is 25 MHz (driven clock only, not a crystal) for RMII - 25 MHz clock mode.
+   */
+  if ((phy_control_2 & (1 << 7)) != (1 << 7)) {
+    phy_control_2 |= 1 << 7;
+    err = mac->write_phy_reg(mac, this->phy_addr_, KSZ80XX_PC2R_REG_ADDR, phy_control_2);
+    ESPHL_ERROR_CHECK(err, "Write PHY Control 2 failed");
+    err = mac->read_phy_reg(mac, this->phy_addr_, KSZ80XX_PC2R_REG_ADDR, &(phy_control_2));
+    ESPHL_ERROR_CHECK(err, "Read PHY Control 2 failed");
+    ESP_LOGVV(TAG, "KSZ8081 PHY Control 2: %s",
+              format_hex_pretty_to(hex_buf, (uint8_t *) &phy_control_2, PHY_REG_SIZE));
+  }
+}
+#endif  // USE_ETHERNET_KSZ8081
+
+void EthernetComponent::write_phy_register_(esp_eth_mac_t *mac, PHYRegister register_data) {
+  esp_err_t err;
+
+#ifdef USE_ETHERNET_RTL8201
+  constexpr uint8_t eth_phy_psr_reg_addr = 0x1F;
+  if (this->type_ == ETHERNET_TYPE_RTL8201 && register_data.page) {
+    ESP_LOGD(TAG, "Select PHY Register Page: 0x%02" PRIX32, register_data.page);
+    err = mac->write_phy_reg(mac, this->phy_addr_, eth_phy_psr_reg_addr, register_data.page);
+    ESPHL_ERROR_CHECK(err, "Select PHY Register page failed");
+  }
+#endif
+
+  ESP_LOGD(TAG, "Writing PHY reg 0x%02" PRIX32 " = 0x%04" PRIX32, register_data.address, register_data.value);
+  err = mac->write_phy_reg(mac, this->phy_addr_, register_data.address, register_data.value);
+  ESPHL_ERROR_CHECK(err, "Writing PHY Register failed");
+
+#ifdef USE_ETHERNET_RTL8201
+  if (this->type_ == ETHERNET_TYPE_RTL8201 && register_data.page) {
+    ESP_LOGD(TAG, "Select PHY Register Page 0x00");
+    err = mac->write_phy_reg(mac, this->phy_addr_, eth_phy_psr_reg_addr, 0x0);
+    ESPHL_ERROR_CHECK(err, "Select PHY Register Page 0 failed");
+  }
+#endif
+}
+
+#ifdef USE_ETHERNET_YT8531
+void EthernetComponent::yt8531_phy_init_() {
+  esp_err_t err;
+
+  // The YT8531 disables auto-negotiation on hardware reset (undocumented behavior), and the
+  // generic 802.3 driver only resets the PHY, so re-enable it (this also updates the driver's
+  // cached auto-nego state used by esp_eth_start()).
+  bool autoneg_enable = true;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_S_AUTONEGO, &autoneg_enable);
+  ESPHL_ERROR_CHECK(err, "YT8531 enable auto-negotiation failed");
+
+  // RGMII needs ~2 ns Tx and Rx clock delays for reliable data sampling. These are set through
+  // the YT8531 extended-register interface: write the ext-register address to 0x1E, then
+  // read/modify/write its value via 0x1F.
+  esp_eth_phy_reg_rw_data_t phy_reg;
+  uint32_t reg_val;
+  phy_reg.reg_value_p = &reg_val;
+
+  // RX ~2 ns coarse delay: EXT_CHIP_CONFIG (0xA001), set rxc_dly_en (bit 8).
+  reg_val = 0xA001;
+  phy_reg.reg_addr = 0x1E;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_WRITE_PHY_REG, &phy_reg);
+  ESPHL_ERROR_CHECK(err, "YT8531 select Chip_Config failed");
+  phy_reg.reg_addr = 0x1F;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_READ_PHY_REG, &phy_reg);
+  ESPHL_ERROR_CHECK(err, "YT8531 read Chip_Config failed");
+  reg_val |= (1U << 8);
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_WRITE_PHY_REG, &phy_reg);
+  ESPHL_ERROR_CHECK(err, "YT8531 write Chip_Config failed");
+
+  // TX ~2 ns delay: EXT_RGMII_CONFIG1 (0xA003), tx_delay_sel[3:0] and tx_delay_sel_fe[7:4] = 13.
+  reg_val = 0xA003;
+  phy_reg.reg_addr = 0x1E;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_WRITE_PHY_REG, &phy_reg);
+  ESPHL_ERROR_CHECK(err, "YT8531 select RGMII_Config1 failed");
+  phy_reg.reg_addr = 0x1F;
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_READ_PHY_REG, &phy_reg);
+  ESPHL_ERROR_CHECK(err, "YT8531 read RGMII_Config1 failed");
+  reg_val = (reg_val & ~0x00FFU) | (13U << 4) | (13U << 0);
+  err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_WRITE_PHY_REG, &phy_reg);
+  ESPHL_ERROR_CHECK(err, "YT8531 write RGMII_Config1 failed");
+}
+#endif
+
+#endif
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ETHERNET && USE_ESP32

--- a/ch390/components/ethernet/ethernet_component_rp2.cpp
+++ b/ch390/components/ethernet/ethernet_component_rp2.cpp
@@ -1,0 +1,383 @@
+#include "ethernet_component.h"
+
+#if defined(USE_ETHERNET) && defined(USE_RP2)
+
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include "esphome/components/rp2/gpio.h"
+
+#include <SPI.h>
+#include <lwip/dns.h>
+#include <lwip/netif.h>
+
+namespace esphome::ethernet {
+
+static const char *const TAG = "ethernet";
+
+void EthernetComponent::setup() {
+  // Configure SPI pins
+#if !defined(USE_ETHERNET_W6300)
+  SPI.setRX(this->miso_pin_);
+  SPI.setTX(this->mosi_pin_);
+  SPI.setSCK(this->clk_pin_);
+#endif
+  // W6300 uses PIO QSPI with hardcoded pins, not Arduino SPI.
+  // SPI pin config is skipped; Wiznet6300lwIPFixed (needsSPI()=false)
+  // prevents LwipIntfDev::begin() from calling SPI.begin().
+
+  // Toggle reset pin if configured
+  if (this->reset_pin_ >= 0) {
+    rp2::RP2GPIOPin reset_pin;
+    reset_pin.set_pin(this->reset_pin_);
+    reset_pin.set_flags(gpio::FLAG_OUTPUT);
+    reset_pin.setup();
+    reset_pin.digital_write(false);
+    delay(1);  // NOLINT
+    reset_pin.digital_write(true);
+    // W5100S needs 150ms for PLL lock; W5500/ENC28J60 need ~10ms
+    delay(RESET_DELAY_MS);  // NOLINT
+  }
+
+  // Create the SPI Ethernet device instance
+#if defined(USE_ETHERNET_W5500)
+  this->eth_ = new Wiznet5500lwIP(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
+#elif defined(USE_ETHERNET_W5100)
+  this->eth_ = new Wiznet5100lwIP(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
+#elif defined(USE_ETHERNET_W6100)
+  this->eth_ = new Wiznet6100lwIP(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
+#elif defined(USE_ETHERNET_W6300)
+  this->eth_ = new Wiznet6300lwIPFixed(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
+#elif defined(USE_ETHERNET_ENC28J60)
+  this->eth_ = new ENC28J60lwIP(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
+#endif
+
+  // Set hostname before begin() so the LWIP netif gets it
+  this->eth_->hostname(App.get_name().c_str());
+
+  // Configure static IP if set (must be done before begin())
+#ifdef USE_ETHERNET_MANUAL_IP
+  if (this->manual_ip_.has_value()) {
+    IPAddress ip(this->manual_ip_->static_ip);
+    IPAddress gateway(this->manual_ip_->gateway);
+    IPAddress subnet(this->manual_ip_->subnet);
+    IPAddress dns1(this->manual_ip_->dns1);
+    IPAddress dns2(this->manual_ip_->dns2);
+    this->eth_->config(ip, gateway, subnet, dns1, dns2);
+  }
+#endif
+
+  // Begin with fixed MAC or auto-generated
+  bool success;
+  if (this->fixed_mac_.has_value()) {
+    success = this->eth_->begin(this->fixed_mac_->data());
+  } else {
+    success = this->eth_->begin();
+  }
+
+  if (!success) {
+    ESP_LOGE(TAG, "Failed to initialize Ethernet");
+    delete this->eth_;  // NOLINT(cppcoreguidelines-owning-memory)
+    this->eth_ = nullptr;
+    this->mark_failed();
+    return;
+  }
+
+  // Make this the default interface for routing
+  this->eth_->setDefault(true);
+
+  // The arduino-pico LwipIntfDev automatically handles packet processing
+  // via __addEthernetPacketHandler when no interrupt pin is used,
+  // or via GPIO interrupt when one is provided.
+
+  // Don't set started_ here — let the link polling in loop() set it
+  // when the link is actually up. Setting it prematurely causes
+  // a "Starting → Stopped → Starting" log sequence because the chip
+  // needs time after begin() before the PHY link is ready.
+}
+
+void EthernetComponent::loop() {
+  // On RP2040, we need to poll connection state since there are no events.
+  const uint32_t now = App.get_loop_component_start_time();
+
+  // Throttle link/IP polling to avoid excessive SPI transactions.
+  // W5500/ENC28J60 read PHY register via SPI on every linkStatus() call.
+  // W5100 can't detect link state, so we skip the SPI read and assume link-up.
+  // connected() reads netif->ip_addr without LwIPLock, but this is a single
+  // 32-bit aligned read (atomic on ARM) — worst case is a one-iteration-stale
+  // value, which is benign for polling.
+  if (this->eth_ != nullptr && now - this->last_link_check_ >= LINK_CHECK_INTERVAL) {
+    this->last_link_check_ = now;
+#if defined(USE_ETHERNET_W5100)
+    // W5100 can't detect link (isLinkDetectable() returns false), so linkStatus()
+    // returns Unknown — assume link is up after successful begin()
+    bool link_up = true;
+#else
+    bool link_up = this->eth_->linkStatus() == LinkON;
+#endif
+    bool has_ip = this->eth_->connected();
+
+    if (!link_up) {
+      if (this->started_) {
+        this->started_ = false;
+        this->connected_ = false;
+      }
+    } else {
+      if (!this->started_) {
+        this->started_ = true;
+      }
+      bool was_connected = this->connected_;
+      this->connected_ = has_ip;
+      if (this->connected_ && !was_connected) {
+#ifdef USE_ETHERNET_IP_STATE_LISTENERS
+        this->notify_ip_state_listeners_();
+#endif
+      }
+    }
+  }
+
+  // State machine
+  switch (this->state_) {
+    case EthernetComponentState::STOPPED:
+      if (this->started_) {
+        ESP_LOGI(TAG, "Starting connection");
+        this->state_ = EthernetComponentState::CONNECTING;
+        this->start_connect_();
+      }
+      break;
+    case EthernetComponentState::CONNECTING:
+      if (!this->started_) {
+        ESP_LOGI(TAG, "Stopped connection");
+        this->state_ = EthernetComponentState::STOPPED;
+      } else if (this->connected_) {
+        // connection established
+        ESP_LOGI(TAG, "Connected");
+        this->state_ = EthernetComponentState::CONNECTED;
+
+        this->dump_connect_params_();
+        this->status_clear_warning();
+#ifdef USE_ETHERNET_CONNECT_TRIGGER
+        this->connect_trigger_.trigger();
+#endif
+      } else if (now - this->connect_begin_ > 15000) {
+        ESP_LOGW(TAG, "Connecting failed; reconnecting");
+        this->start_connect_();
+      }
+      break;
+    case EthernetComponentState::CONNECTED:
+      if (!this->started_) {
+        ESP_LOGI(TAG, "Stopped connection");
+        this->state_ = EthernetComponentState::STOPPED;
+#ifdef USE_ETHERNET_DISCONNECT_TRIGGER
+        this->disconnect_trigger_.trigger();
+#endif
+      } else if (!this->connected_) {
+        ESP_LOGW(TAG, "Connection lost; reconnecting");
+        this->state_ = EthernetComponentState::CONNECTING;
+        this->start_connect_();
+#ifdef USE_ETHERNET_DISCONNECT_TRIGGER
+        this->disconnect_trigger_.trigger();
+#endif
+      } else {
+        this->finish_connect_();
+      }
+      break;
+  }
+}
+
+void EthernetComponent::dump_config() {
+  const char *type_str = "Unknown";
+#if defined(USE_ETHERNET_W5500)
+  type_str = "W5500";
+#elif defined(USE_ETHERNET_W5100)
+  type_str = "W5100";
+#elif defined(USE_ETHERNET_W6100)
+  type_str = "W6100";
+#elif defined(USE_ETHERNET_W6300)
+  type_str = "W6300";
+#elif defined(USE_ETHERNET_ENC28J60)
+  type_str = "ENC28J60";
+#endif
+#if defined(USE_ETHERNET_W6300)
+  // W6300 uses PIO QSPI with hardcoded pins — SPI pin fields are not used
+  ESP_LOGCONFIG(TAG,
+                "Ethernet:\n"
+                "  Type: %s (PIO QSPI)\n"
+                "  Connected: %s\n"
+                "  IRQ Pin: %d\n"
+                "  Reset Pin: %d",
+                type_str, YESNO(this->is_connected()), this->interrupt_pin_, this->reset_pin_);
+#else
+  ESP_LOGCONFIG(TAG,
+                "Ethernet:\n"
+                "  Type: %s\n"
+                "  Connected: %s\n"
+                "  CLK Pin: %u\n"
+                "  MISO Pin: %u\n"
+                "  MOSI Pin: %u\n"
+                "  CS Pin: %u\n"
+                "  IRQ Pin: %d\n"
+                "  Reset Pin: %d",
+                type_str, YESNO(this->is_connected()), this->clk_pin_, this->miso_pin_, this->mosi_pin_, this->cs_pin_,
+                this->interrupt_pin_, this->reset_pin_);
+#endif
+  this->dump_connect_params_();
+}
+
+network::IPAddresses EthernetComponent::get_ip_addresses() {
+  network::IPAddresses addresses;
+  if (this->eth_ != nullptr) {
+    LwIPLock lock;
+    addresses[0] = network::IPAddress(this->eth_->localIP());
+  }
+  return addresses;
+}
+
+network::IPAddress EthernetComponent::get_dns_address(uint8_t num) {
+  LwIPLock lock;
+  const ip_addr_t *dns_ip = dns_getserver(num);
+  return dns_ip;
+}
+
+void EthernetComponent::get_eth_mac_address_raw(uint8_t *mac) {
+  if (this->eth_ != nullptr) {
+    this->eth_->macAddress(mac);
+  } else {
+    memset(mac, 0, 6);
+  }
+}
+
+std::string EthernetComponent::get_eth_mac_address_pretty() {
+  char buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  return std::string(this->get_eth_mac_address_pretty_into_buffer(buf));
+}
+
+const char *EthernetComponent::get_eth_mac_address_pretty_into_buffer(
+    std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buf) {
+  uint8_t mac[6];
+  get_eth_mac_address_raw(mac);
+  format_mac_addr_upper(mac, buf.data());
+  return buf.data();
+}
+
+eth_duplex_t EthernetComponent::get_duplex_mode() {
+  // W5100, W5500, and ENC28J60 are full-duplex on RP2040
+  return ETH_DUPLEX_FULL;
+}
+
+eth_speed_t EthernetComponent::get_link_speed() {
+#ifdef USE_ETHERNET_ENC28J60
+  // ENC28J60 is 10Mbps only
+  return ETH_SPEED_10M;
+#else
+  // W5100 and W5500 are 100Mbps
+  return ETH_SPEED_100M;
+#endif
+}
+
+bool EthernetComponent::powerdown() {
+  ESP_LOGI(TAG, "Powering down ethernet");
+  if (this->eth_ != nullptr) {
+    this->eth_->end();
+  }
+  this->connected_ = false;
+  this->started_ = false;
+  return true;
+}
+
+void EthernetComponent::start_connect_() {
+  this->got_ipv4_address_ = false;
+  this->connect_begin_ = millis();
+  this->status_set_warning(LOG_STR("waiting for IP configuration"));
+
+  // Hostname is already set in setup() via LwipIntf::setHostname()
+
+#ifdef USE_ETHERNET_MANUAL_IP
+  if (this->manual_ip_.has_value()) {
+    // Static IP was already configured before begin() in setup()
+    // Set DNS servers
+    LwIPLock lock;
+    if (this->manual_ip_->dns1.is_set()) {
+      ip_addr_t d;
+      d = this->manual_ip_->dns1;
+      dns_setserver(0, &d);
+    }
+    if (this->manual_ip_->dns2.is_set()) {
+      ip_addr_t d;
+      d = this->manual_ip_->dns2;
+      dns_setserver(1, &d);
+    }
+  }
+#endif
+}
+
+void EthernetComponent::finish_connect_() {
+  // No additional work needed on RP2040 for now
+  // IPv6 link-local could be added here in the future
+}
+
+void EthernetComponent::dump_connect_params_() {
+  if (this->eth_ == nullptr) {
+    return;
+  }
+
+  char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char subnet_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char gateway_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char dns1_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char dns2_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+
+  // Copy all lwIP state under the lock to avoid races with IRQ callbacks
+  ip_addr_t ip_addr, netmask, gw, dns1_addr, dns2_addr;
+  {
+    LwIPLock lock;
+    auto *netif = this->eth_->getNetIf();
+    ip_addr = netif->ip_addr;
+    netmask = netif->netmask;
+    gw = netif->gw;
+    dns1_addr = *dns_getserver(0);
+    dns2_addr = *dns_getserver(1);
+  }
+  ESP_LOGCONFIG(TAG,
+                "  IP Address: %s\n"
+                "  Hostname: '%s'\n"
+                "  Subnet: %s\n"
+                "  Gateway: %s\n"
+                "  DNS1: %s\n"
+                "  DNS2: %s\n"
+                "  MAC Address: %s",
+                network::IPAddress(&ip_addr).str_to(ip_buf), App.get_name().c_str(),
+                network::IPAddress(&netmask).str_to(subnet_buf), network::IPAddress(&gw).str_to(gateway_buf),
+                network::IPAddress(&dns1_addr).str_to(dns1_buf), network::IPAddress(&dns2_addr).str_to(dns2_buf),
+                this->get_eth_mac_address_pretty_into_buffer(mac_buf));
+}
+
+void EthernetComponent::set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
+void EthernetComponent::set_miso_pin(uint8_t miso_pin) { this->miso_pin_ = miso_pin; }
+void EthernetComponent::set_mosi_pin(uint8_t mosi_pin) { this->mosi_pin_ = mosi_pin; }
+void EthernetComponent::set_cs_pin(uint8_t cs_pin) { this->cs_pin_ = cs_pin; }
+void EthernetComponent::set_interrupt_pin(int8_t interrupt_pin) { this->interrupt_pin_ = interrupt_pin; }
+void EthernetComponent::set_reset_pin(int8_t reset_pin) { this->reset_pin_ = reset_pin; }
+
+void EthernetComponent::enable() {
+  // RP2040 uses arduino-pico's LwipIntfDev which manages link state internally;
+  // there is no clean enable/disable hook today. The YAML option is accepted on
+  // RP2040 for schema parity but has no effect.
+  if (!this->disabled_)
+    return;
+  ESP_LOGW(TAG, "enable_on_boot/disable not supported");
+  this->disabled_ = false;
+}
+
+void EthernetComponent::disable() {
+  if (this->disabled_)
+    return;
+  ESP_LOGW(TAG, "enable_on_boot/disable not supported");
+  this->disabled_ = true;
+}
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ETHERNET && USE_RP2

--- a/ch390/components/ethernet/ethernet_helpers.c
+++ b/ch390/components/ethernet/ethernet_helpers.c
@@ -1,0 +1,13 @@
+#include "esphome/core/defines.h"
+#ifdef USE_ESP32
+#include "esp_eth_mac_esp.h"
+
+// ETH_ESP32_EMAC_DEFAULT_CONFIG() uses out-of-order designated initializers
+// which are valid in C but not in C++. This wrapper allows C++ code to get
+// the default config without replicating the macro's contents.
+#if CONFIG_ETH_USE_ESP32_EMAC
+eth_esp32_emac_config_t eth_esp32_emac_default_config(void) {
+  return (eth_esp32_emac_config_t) ETH_ESP32_EMAC_DEFAULT_CONFIG();
+}
+#endif
+#endif  // USE_ESP32

--- a/ch390/components/ethernet/w5500_custom_spi.cpp
+++ b/ch390/components/ethernet/w5500_custom_spi.cpp
@@ -1,0 +1,118 @@
+#include "w5500_custom_spi.h"
+
+#if defined(USE_ESP32) && defined(USE_ETHERNET_W5500)
+
+#include <driver/spi_master.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <cstring>
+#include <new>
+
+namespace esphome::ethernet {
+
+namespace {
+
+// Per-device context returned by init() and handed back to read/write/deinit.
+struct W5500CustomSpiContext {
+  spi_device_handle_t handle;
+  SemaphoreHandle_t lock;
+};
+
+// Transfers up to the ESP32 SPI hardware FIFO size (64 bytes) stay on the polling path; larger
+// transfers (the frame payloads) use the blocking, DMA-backed transmit.
+constexpr uint32_t W5500_SPI_BULK_THRESHOLD = 64;
+constexpr uint32_t W5500_SPI_LOCK_TIMEOUT_MS = 50;
+
+void *w5500_custom_spi_init(const void *spi_config) {
+  const auto *config = static_cast<const eth_w5500_config_t *>(spi_config);
+  auto *ctx = new (std::nothrow) W5500CustomSpiContext{};
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+  // The W5500 SPI frame carries the 16-bit address in the command phase and the 8-bit control
+  // byte in the address phase; mirror what the stock driver configures.
+  spi_device_interface_config_t devcfg = *config->spi_devcfg;
+  devcfg.command_bits = 16;
+  devcfg.address_bits = 8;
+  if (spi_bus_add_device(config->spi_host_id, &devcfg, &ctx->handle) != ESP_OK) {
+    delete ctx;
+    return nullptr;
+  }
+  ctx->lock = xSemaphoreCreateMutex();
+  if (ctx->lock == nullptr) {
+    spi_bus_remove_device(ctx->handle);
+    delete ctx;
+    return nullptr;
+  }
+  return ctx;
+}
+
+esp_err_t w5500_custom_spi_deinit(void *spi_ctx) {
+  auto *ctx = static_cast<W5500CustomSpiContext *>(spi_ctx);
+  spi_bus_remove_device(ctx->handle);
+  vSemaphoreDelete(ctx->lock);
+  delete ctx;
+  return ESP_OK;
+}
+
+// Runs one transaction under the device lock, choosing the polling vs blocking transmit by size.
+// Bulk payloads (> FIFO size) block so the calling task sleeps while DMA runs; small register
+// accesses stay on the cheaper polling path. Used by both read and write.
+esp_err_t w5500_custom_spi_transfer(W5500CustomSpiContext *ctx, spi_transaction_t *trans, uint32_t len) {
+  if (xSemaphoreTake(ctx->lock, pdMS_TO_TICKS(W5500_SPI_LOCK_TIMEOUT_MS)) != pdTRUE) {
+    return ESP_ERR_TIMEOUT;
+  }
+  esp_err_t ret;
+  if (len > W5500_SPI_BULK_THRESHOLD) {
+    ret = spi_device_transmit(ctx->handle, trans);
+  } else {
+    ret = spi_device_polling_transmit(ctx->handle, trans);
+  }
+  xSemaphoreGive(ctx->lock);
+  return ret;
+}
+
+esp_err_t w5500_custom_spi_write(void *spi_ctx, uint32_t cmd, uint32_t addr, const void *data, uint32_t len) {
+  auto *ctx = static_cast<W5500CustomSpiContext *>(spi_ctx);
+  spi_transaction_t trans = {};
+  trans.cmd = static_cast<uint16_t>(cmd);
+  trans.addr = addr;
+  trans.length = 8 * len;
+  trans.tx_buffer = data;
+  return w5500_custom_spi_transfer(ctx, &trans, len);
+}
+
+esp_err_t w5500_custom_spi_read(void *spi_ctx, uint32_t cmd, uint32_t addr, void *data, uint32_t len) {
+  auto *ctx = static_cast<W5500CustomSpiContext *>(spi_ctx);
+  spi_transaction_t trans = {};
+  // Reads of <= 4 bytes use the transaction's inline RX buffer to avoid 4-byte boundary
+  // overwrites of adjacent registers (same guard the stock driver uses).
+  const bool use_rxdata = len <= 4;
+  trans.flags = use_rxdata ? SPI_TRANS_USE_RXDATA : 0;
+  trans.cmd = static_cast<uint16_t>(cmd);
+  trans.addr = addr;
+  trans.length = 8 * len;
+  trans.rx_buffer = data;
+  esp_err_t ret = w5500_custom_spi_transfer(ctx, &trans, len);
+  if (use_rxdata && (ret == ESP_OK)) {
+    memcpy(data, trans.rx_data, len);
+  }
+  return ret;
+}
+
+}  // namespace
+
+void install_w5500_async_spi(eth_w5500_config_t &config) {
+  // Point the custom driver's config at the W5500 config itself; init() reads spi_host_id and
+  // spi_devcfg back out of it. The self-reference is valid because both the config and the
+  // spi_devcfg it points at outlive the esp_eth_mac_new_w5500() call that runs init().
+  config.custom_spi_driver.config = &config;
+  config.custom_spi_driver.init = w5500_custom_spi_init;
+  config.custom_spi_driver.deinit = w5500_custom_spi_deinit;
+  config.custom_spi_driver.read = w5500_custom_spi_read;
+  config.custom_spi_driver.write = w5500_custom_spi_write;
+}
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ESP32 && USE_ETHERNET_W5500

--- a/ch390/components/ethernet/w5500_custom_spi.h
+++ b/ch390/components/ethernet/w5500_custom_spi.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) && defined(USE_ETHERNET_W5500)
+
+#include <esp_idf_version.h>
+// IDF 6.0 moved the per-chip SPI MAC drivers to the Espressif Component Registry; eth_w5500_config_t
+// is no longer reachable through esp_eth.h and needs the explicit header.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <esp_eth_mac_w5500.h>
+#else
+#include <esp_eth.h>
+#endif
+
+namespace esphome::ethernet {
+
+// Installs a custom W5500 SPI driver that offloads the bulk frame transfers off the busy-wait path.
+//
+// The stock W5500 driver runs every SPI transfer through spi_device_polling_transmit(), which
+// busy-waits the CPU for the whole transfer. The frame payload (one large read per received frame,
+// one large write per transmitted frame) is by far the biggest transfer, so the RX task and the TX
+// caller each spin for hundreds of microseconds per frame. This driver sends payload transfers
+// through the blocking, interrupt-driven spi_device_transmit() instead, so the calling task sleeps
+// while DMA moves the bytes. Small register accesses stay on the polling path, where the busy-wait
+// is cheaper than an interrupt round-trip.
+//
+// Must be called before esp_eth_mac_new_w5500(). The driver reads spi_host_id and spi_devcfg back
+// out of `config` in its init() callback, so `config` (and the spi_devcfg it points at) must stay
+// alive until esp_eth_mac_new_w5500() returns.
+void install_w5500_async_spi(eth_w5500_config_t &config);
+
+}  // namespace esphome::ethernet
+
+#endif  // USE_ESP32 && USE_ETHERNET_W5500

--- a/templates/elecrow-thinknode-m7.yaml
+++ b/templates/elecrow-thinknode-m7.yaml
@@ -1,0 +1,145 @@
+# External usage:
+# packages:
+#   device: github://ptr727/ESPHome-Config/templates/elecrow-thinknode-m7.yaml@main
+# - Secrets resolve from a secrets.yaml beside the including config, see secrets._yaml for the names.
+
+# Required substitutions:
+# device_name
+# device_friendly_name
+
+# Required external components:
+# ethernet, from the patched copy in ch390/components, which adds the CH390 type ESPHome lacks.
+# - The including config declares it, because a local path resolves against that config's own directory.
+# - Upstream as esphome/esphome#18226, and the block goes away once that merges and ships in a release.
+# - Not `source: github://pr#18226`: that component is based on dev and imports get_network_priority from the
+#   core network component, which the installed release lacks, and external_components shadows ethernet only.
+
+# Elecrow ThinkNode M7
+# ESP32-S3 QFN56 rev v0.2, 8MB Quad Flash, 8MB Octal PSRAM, 40MHz crystal
+
+# Board tested: hardware verified 2026-08-09, link up and DHCP lease acquired
+
+# WCH CH343 USB-UART bridge on UART0, so there is no native USB CDC and flashing needs no adapter.
+
+# WCH CH390 SPI Ethernet, MAC and PHY in one part, 10/100
+# GPIO47 : sclk
+# GPIO48 : mosi
+# GPIO14 : miso
+# GPIO21 : cs
+# GPIO45 : interrupt
+# - The part reports vendor 0x1C00 and product 0x9151, so the DM9051 driver rejects it on its ID check.
+# - The board declares no reset pin, so none is configured.
+
+# GPIO3  : Status LED (Green) : ESPHome status, lit is healthy and flashing is a warning or error
+# GPIO46 : LoRa TX LED (Blue) : declared as an output and left for the radio to drive
+
+# GPIO4 : User button, an ADC ladder rather than a discrete input, so it is exposed as a voltage
+# - Read it to characterise the ladder before treating any threshold as a button press.
+
+# GPIO17 : i2c sda
+# GPIO18 : i2c scl
+# - The bus takes an optional RTC at 0x68, 0x52, 0x51, or 0x32, and scans clean when none is fitted.
+
+# Semtech LR1110 LoRa on the board's default SPI bus, deliberately not configured
+# GPIO11 : sclk
+# GPIO9  : miso
+# GPIO10 : mosi
+# GPIO12 : nss
+# GPIO13 : busy
+# GPIO38 : dio1
+# GPIO39 : reset, active low
+# - ESPHome has no LR11xx component, and the SX126x components do not fit because the command sets differ.
+# - The RF switch is on the radio's own DIO5 and DIO6 rather than ESP32 pins, and TCXO is on DIO3 at 1.8V.
+# - This is a second bus, so anything claiming it must not assume the ethernet SPI interface.
+
+# https://esphome.io/components/esphome
+esphome:
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+
+# https://esphome.io/components/esp32
+esp32:
+  # A bare ESP32-S3 with external flash, which is the DevKitC-1 profile, there is no WROOM module fitted.
+  # https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html
+  board: esp32-s3-devkitc-1
+
+  # The board definition does not set this, ESPHome defaults to 4MB.
+  flash_size: 8MB
+
+  # https://esphome.io/components/esp32#esp-idf-framework
+  framework:
+    type: esp-idf
+
+# https://esphome.io/components/psram
+# The part carries 8MB in package, so octal, and ESPHome has no default mode on the S3.
+psram:
+  mode: octal
+  speed: 80MHz
+
+# The ethernet component conflicts with wifi, so common.yaml cannot be used here.
+# https://esphome.io/components/packages#local-packages
+packages:
+  api: !include api.yaml
+  basic: !include basic.yaml
+  debug: !include debug.yaml
+  ethernetsensor: !include ethernet-sensor.yaml
+  logger: !include logger.yaml
+  ota: !include ota.yaml
+  temperature: !include temperature.yaml
+  time: !include time.yaml
+
+# Match the port the board is programmed through, UART0 is the CH343 bridge.
+# https://esphome.io/components/logger
+logger:
+  hardware_uart: UART0 # UART0, USB_CDC, USB_SERIAL_JTAG
+
+# The device sets no domain, so it is reachable only by whatever DHCP registered for it.
+# https://esphome.io/components/ethernet
+ethernet:
+  type: CH390
+  clk_pin: GPIO47
+  mosi_pin: GPIO48
+  miso_pin: GPIO14
+  cs_pin: GPIO21
+  interrupt_pin: GPIO45
+  clock_speed: 20MHz
+
+# https://esphome.io/components/status_led
+# The LED is active low and the pin is deliberately not inverted, so lit means healthy.
+# An ethernet disconnect raises a component warning, which flashes this LED.
+status_led:
+  pin:
+    number: GPIO3 # Strapping pin, fixed board wiring, so the warning is acknowledged.
+    ignore_strapping_warning: true
+
+# https://esphome.io/components/i2c
+i2c:
+  sda: GPIO17
+  scl: GPIO18
+  scan: true
+
+# https://esphome.io/components/output
+output:
+
+  # https://esphome.io/components/output/gpio
+  # Claimed by the radio, so the board template only declares it.
+  - platform: gpio
+    id: led_lora
+    pin:
+      number: GPIO46 # Strapping pin, fixed board wiring, so the warning is acknowledged.
+      inverted: true
+      ignore_strapping_warning: true
+
+# https://esphome.io/components/sensor
+sensor:
+
+  # https://esphome.io/components/sensor/adc
+  # The user button is an ADC ladder with no documented threshold, so report the raw voltage.
+  - platform: adc
+    name: "User Button Voltage"
+    id: user_button_voltage
+    pin: GPIO4
+    attenuation: 12db
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 60s

--- a/test/elecrow-thinknode-m7.yaml
+++ b/test/elecrow-thinknode-m7.yaml
@@ -1,0 +1,19 @@
+# CI compile-test for templates/elecrow-thinknode-m7.yaml
+substitutions:
+  device_name: elecrow-thinknode-m7-test
+  device_friendly_name: "Elecrow ThinkNode M7 Test"
+
+packages:
+  device: !include ../templates/elecrow-thinknode-m7.yaml
+
+# The template needs the CH390 ethernet type, which ESPHome does not ship yet.
+# Tracked upstream as esphome/esphome#18226, and the block goes away once that merges and releases.
+# A local path resolves against this config's own directory, hence the ../ from test/.
+# Local, not `source: github://pr#18226`: that fetches the PR's ethernet component, which is based on dev
+# and imports get_network_priority from the core network component, absent in the installed release.
+# external_components shadows ethernet only, so the dev component meets a release core and the import fails.
+external_components:
+  - source:
+      type: local
+      path: ../ch390/components
+    components: [ethernet]

--- a/thinknode-m7-bench.yaml
+++ b/thinknode-m7-bench.yaml
@@ -1,0 +1,182 @@
+# One flash that answers both open hardware questions, because every ESPHome flash costs a repartition here.
+# Ethernet runs in polling mode rather than on the interrupt, which is the CH390 path the upstream PR cannot yet claim.
+# The LR11xx GetVersion probe reads the radio's identity from a stack that assumes nothing about which part is fitted.
+# Restore meshcore with its merged image at 0x0 afterwards, since this replaces the partition table.
+
+# https://esphome.io/components/substitutions
+substitutions:
+  device_name: thinknode-m7-bench
+  device_friendly_name: "ThinkNode M7 Bench"
+
+# https://esphome.io/components/packages
+# ESPHome owns the partition table now, so an OTA is safe here and every later bench flash goes over the wire.
+packages:
+  ota: !include templates/ota.yaml
+
+# Elecrow ThinkNode M7
+# Ethernet is the CH390 on SPI2, and the radio is an LR11xx on SPI3, so the two buses never contend.
+# GPIO47 : eth sclk    GPIO48 : eth mosi   GPIO14 : eth miso   GPIO21 : eth cs
+# GPIO11 : lora sclk   GPIO10 : lora mosi  GPIO9  : lora miso  GPIO12 : lora nss
+# GPIO13 : lora busy   GPIO39 : lora reset, active low
+# - GPIO45, the ethernet interrupt, is deliberately unused here so polling carries the traffic.
+
+# https://esphome.io/components/esphome
+esphome:
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+  on_boot:
+    # Release the radio's reset and let it boot before the first command.
+    priority: -100
+    then:
+      - output.turn_off: lora_reset
+      - delay: 20ms
+      - output.turn_on: lora_reset
+      - delay: 500ms
+
+# https://esphome.io/components/esp32
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 8MB
+
+  # https://esphome.io/components/esp32#esp-idf-framework
+  framework:
+    type: esp-idf
+
+# https://esphome.io/components/psram
+psram:
+  mode: octal
+  speed: 80MHz
+
+# https://esphome.io/components/logger
+logger:
+  level: debug # none, error, warn, info, debug, verbose, very_verbose
+  hardware_uart: UART0 # UART0, USB_CDC, USB_SERIAL_JTAG
+
+# https://esphome.io/components/external_components
+external_components:
+  - source:
+      type: local
+      path: ch390/components
+    components: [ethernet]
+
+# https://esphome.io/components/ethernet
+# polling_interval replaces interrupt_pin, so a link and a DHCP lease here prove the polling path end to end.
+# Verified on hardware 2026-08-09, GPIO45 left unwired.
+# - Latency is base + uniform[0, polling_interval], so mean RTT is base + interval/2.
+# - Measured at 50ms: min 3.20ms, mean 26.59ms, max 51.87ms, mdev 14.22ms against a predicted 14.43 for uniform width 50.
+# - Base is about 3ms, matching a W5500 on the same LAN, so the driver itself costs nothing beyond the poll wait.
+# - Sample RTT with a ping interval that is not a multiple of polling_interval, or every probe lands on the same poll phase.
+# A 2x2 over mode and clock_speed, 10000 full MTU frames each, found no defect specific to polling.
+# - ICMP loss ran 0.03 to 0.18 percent in every cell and is lwIP queue behaviour under flood, not a CH390 fault.
+# - Interrupt mode lost more than polling in the 20MHz pair, so loss does not track the mode.
+# - Driver level "frame read from module failed" is rare, sporadic, and did not reproduce on its own config.
+ethernet:
+  type: CH390
+  clk_pin: GPIO47
+  mosi_pin: GPIO48
+  miso_pin: GPIO14
+  cs_pin: GPIO21
+  polling_interval: 10ms
+  clock_speed: 20MHz
+  domain: !secret wifi_domain
+
+# https://esphome.io/components/mdns
+# Disabled so a name resolves only through the DHCP registered record.
+mdns:
+  disabled: true
+
+# https://esphome.io/components/spi
+# SPI3, because the ethernet component takes SPI2 and the two would otherwise collide.
+spi:
+  id: lora_bus
+  clk_pin: GPIO11
+  mosi_pin: GPIO10
+  miso_pin: GPIO9
+  interface: spi3
+
+# https://esphome.io/components/spi_device
+# LR11xx is SPI mode 0, MSB first, and 1MHz keeps a first read well inside spec.
+spi_device:
+  - id: lora_chip
+    spi_id: lora_bus
+    cs_pin: GPIO12
+    data_rate: 1MHz
+    spi_mode: mode0
+
+# https://esphome.io/components/output
+output:
+
+  # https://esphome.io/components/output/gpio
+  # NRESET is active low, so on is the released state.
+  - platform: gpio
+    id: lora_reset
+    pin: GPIO39
+
+# https://esphome.io/components/binary_sensor
+binary_sensor:
+
+  # https://esphome.io/components/binary_sensor/gpio
+  # BUSY high means the radio has not finished the previous command.
+  - platform: gpio
+    name: "LoRa Busy"
+    id: lora_busy
+    pin: GPIO13
+
+  # https://esphome.io/components/binary_sensor/gpio
+  # The front button, GPIO4 active low with a pullup, per Meshtastic's ELECROW-ThinkNode-M7 variant.
+  # A deliberate hold restarts rather than a tap, so a brush against the case cannot reboot a run mid measurement.
+  - platform: gpio
+    name: "Button"
+    id: user_button
+    pin:
+      number: GPIO4
+      mode:
+        input: true
+        pullup: true
+      inverted: true
+    on_click:
+      min_length: 1s
+      max_length: 5s
+      then:
+        - button.press: restart_device
+
+# https://esphome.io/components/button
+button:
+
+  # https://esphome.io/components/button/restart
+  # A software restart, so it reboots the running image and never enters the bootloader.
+  - platform: restart
+    name: "Restart"
+    id: restart_device
+
+# https://esphome.io/components/text_sensor
+text_sensor:
+
+  # https://esphome.io/components/text_sensor/ethernet_info
+  # These print on connect, which is the polling-mode result.
+  - platform: ethernet_info
+    ip_address:
+      name: "IP Address"
+    mac_address:
+      name: "MAC Address"
+
+# https://esphome.io/components/interval
+interval:
+  - interval: 5s
+    then:
+      - lambda: |-
+          // LR11xx splits a command from its response: write the opcode, drop CS, wait, then read.
+          // The read returns a stat byte first, then hw, type, and the two firmware bytes.
+          uint8_t rsp[5] = {0};
+          id(lora_chip)->enable();
+          id(lora_chip)->write_byte(0x01);
+          id(lora_chip)->write_byte(0x01);
+          id(lora_chip)->disable();
+          delayMicroseconds(500);
+          id(lora_chip)->enable();
+          for (int i = 0; i < 5; i++) {
+            rsp[i] = id(lora_chip)->read_byte();
+          }
+          id(lora_chip)->disable();
+          ESP_LOGI("loraid", "stat 0x%02X  hw 0x%02X  type 0x%02X  fw 0x%02X%02X  busy %d", rsp[0], rsp[1], rsp[2],
+                   rsp[3], rsp[4], id(lora_busy).state);

--- a/thinknode-m7-bench.yaml
+++ b/thinknode-m7-bench.yaml
@@ -70,6 +70,12 @@ external_components:
 # - ICMP loss ran 0.03 to 0.18 percent in every cell and is lwIP queue behaviour under flood, not a CH390 fault.
 # - Interrupt mode lost more than polling in the 20MHz pair, so loss does not track the mode.
 # - Driver level "frame read from module failed" is rare, sporadic, and did not reproduce on its own config.
+# The schema default of 26.67MHz was added to that matrix on 2026-08-10, by omitting clock_speed entirely.
+# - Polling lost 0.12 and 0.03 percent over two runs, interrupt 0.09 percent, all inside the 0.03 to 0.18 spread above.
+# - CH390DS1 v1.8 tables 9-4 and 9-5 give SCK as 50MHz typical and 72MHz maximum at VDDIO 3.3V, no minimum stated.
+# - The sheet is at https://www.wch-ic.com/downloads/CH390DS1_PDF.html, and its site needs a browser rather than curl.
+# - So the 26.67MHz default is in spec and the shared schema's 80MHz ceiling is not, which the upstream PR now caps.
+# - dump_config prints "Clock Speed: 26 MHz" for it, since it truncates to whole MHz.
 ethernet:
   type: CH390
   clk_pin: GPIO47

--- a/thinknode-m7-ethid.yaml
+++ b/thinknode-m7-ethid.yaml
@@ -1,0 +1,73 @@
+# Reads the ethernet controller's ID registers over raw SPI, because the DM9051 driver rejects the part without saying what it found.
+# The driver demands vendor 0x0A46 then product 0x9051, and it failed on vendor, which a CH390 and a dead bus both produce.
+# A plausible vendor word means the wiring is right and only the ID check stands in the way.
+# All 0x00 or all 0xFF means nothing is answering and the pin map is wrong.
+
+# https://esphome.io/components/substitutions
+substitutions:
+  device_name: thinknode-m7-ethid
+  device_friendly_name: "ThinkNode M7 Ethernet ID"
+
+# Elecrow ThinkNode M7, WCH CH390 driven as its register-compatible Davicom DM9051.
+# GPIO47 : sclk
+# GPIO48 : mosi
+# GPIO14 : miso
+# GPIO21 : cs
+# - The ethernet component is absent here, so the bus is the ordinary spi component instead.
+
+# https://esphome.io/components/esphome
+esphome:
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+
+# https://esphome.io/components/esp32
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 8MB
+
+  # https://esphome.io/components/esp32#esp-idf-framework
+  framework:
+    type: esp-idf
+
+# https://esphome.io/components/psram
+psram:
+  mode: octal
+  speed: 80MHz
+
+# https://esphome.io/components/logger
+logger:
+  level: debug # none, error, warn, info, debug, verbose, very_verbose
+  hardware_uart: UART0 # UART0, USB_CDC, USB_SERIAL_JTAG
+
+# https://esphome.io/components/spi
+spi:
+  id: eth_bus
+  clk_pin: GPIO47
+  mosi_pin: GPIO48
+  miso_pin: GPIO14
+
+# https://esphome.io/components/spi_device
+# 1MHz because a first read has to survive whatever the CS setup time turns out to be.
+spi_device:
+  - id: eth_chip
+    spi_id: eth_bus
+    cs_pin: GPIO21
+    data_rate: 1MHz
+    spi_mode: mode0
+
+# https://esphome.io/components/interval
+# Repeated so a one-off glitch reads differently from a stable wrong answer.
+interval:
+  - interval: 5s
+    then:
+      - lambda: |-
+          // Read is the register address with bit 7 clear, then one byte back, which is what the DM9051 driver puts on the wire.
+          uint8_t v[6];
+          const uint8_t regs[6] = {0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x00};
+          for (int i = 0; i < 6; i++) {
+            id(eth_chip)->enable();
+            id(eth_chip)->write_byte(regs[i]);
+            v[i] = id(eth_chip)->read_byte();
+            id(eth_chip)->disable();
+          }
+          ESP_LOGI("ethid", "VID 0x%02X%02X  PID 0x%02X%02X  REV 0x%02X  NCR 0x%02X", v[1], v[0], v[3], v[2], v[4], v[5]);

--- a/thinknode-m7-loraid.yaml
+++ b/thinknode-m7-loraid.yaml
@@ -1,0 +1,107 @@
+# Reads the LoRa radio's version over raw SPI, the same trick that identified the CH390.
+# The M7 carries a Semtech LR1110, not an SX1262, so its command set is LR11xx and not SX126x.
+# GetVersion is opcode 0x0101 and needs no TCXO and no configuration, which makes it a pure presence test.
+# A type byte of 0x01 is an LR1110, 0x02 an LR1120, 0x03 an LR1121, and 0x00 or 0xFF means nothing is answering.
+
+# https://esphome.io/components/substitutions
+substitutions:
+  device_name: thinknode-m7-loraid
+  device_friendly_name: "ThinkNode M7 LoRa ID"
+
+# Elecrow ThinkNode M7, Semtech LR1110 on its own SPI bus.
+# GPIO11 : sclk
+# GPIO9  : miso
+# GPIO10 : mosi
+# GPIO12 : nss
+# GPIO13 : busy
+# GPIO39 : reset, active low
+# - DIO1 on GPIO38 is unused here, since nothing waits on an interrupt.
+# - The ethernet component is absent, so this bus does not contend with it.
+
+# https://esphome.io/components/esphome
+esphome:
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+  on_boot:
+    # Release reset and give the radio time to boot before the first command.
+    priority: -100
+    then:
+      - output.turn_off: lora_reset
+      - delay: 20ms
+      - output.turn_on: lora_reset
+      - delay: 500ms
+
+# https://esphome.io/components/esp32
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 8MB
+
+  # https://esphome.io/components/esp32#esp-idf-framework
+  framework:
+    type: esp-idf
+
+# https://esphome.io/components/psram
+psram:
+  mode: octal
+  speed: 80MHz
+
+# https://esphome.io/components/logger
+logger:
+  level: debug # none, error, warn, info, debug, verbose, very_verbose
+  hardware_uart: UART0 # UART0, USB_CDC, USB_SERIAL_JTAG
+
+# https://esphome.io/components/spi
+spi:
+  id: lora_bus
+  clk_pin: GPIO11
+  mosi_pin: GPIO10
+  miso_pin: GPIO9
+
+# https://esphome.io/components/spi_device
+# LR11xx is SPI mode 0, MSB first, and 1MHz keeps a first read well inside spec.
+spi_device:
+  - id: lora_chip
+    spi_id: lora_bus
+    cs_pin: GPIO12
+    data_rate: 1MHz
+    spi_mode: mode0
+
+# https://esphome.io/components/output
+output:
+
+  # https://esphome.io/components/output/gpio
+  # NRESET is active low, so on is the released state.
+  - platform: gpio
+    id: lora_reset
+    pin: GPIO39
+
+# https://esphome.io/components/binary_sensor
+binary_sensor:
+
+  # https://esphome.io/components/binary_sensor/gpio
+  # BUSY high means the radio has not finished the previous command.
+  - platform: gpio
+    name: "LoRa Busy"
+    id: lora_busy
+    pin: GPIO13
+
+# https://esphome.io/components/interval
+interval:
+  - interval: 5s
+    then:
+      - lambda: |-
+          // LR11xx splits a command from its response: write the opcode, drop CS, wait for BUSY to fall, then read.
+          // The read returns a stat byte first, then hw, type, and the two firmware bytes.
+          uint8_t rsp[5] = {0};
+          id(lora_chip)->enable();
+          id(lora_chip)->write_byte(0x01);
+          id(lora_chip)->write_byte(0x01);
+          id(lora_chip)->disable();
+          delayMicroseconds(500);
+          id(lora_chip)->enable();
+          for (int i = 0; i < 5; i++) {
+            rsp[i] = id(lora_chip)->read_byte();
+          }
+          id(lora_chip)->disable();
+          ESP_LOGI("loraid", "stat 0x%02X  hw 0x%02X  type 0x%02X  fw 0x%02X%02X  busy %d", rsp[0], rsp[1], rsp[2],
+                   rsp[3], rsp[4], id(lora_busy).state);

--- a/thinknode-m7-nettest.yaml
+++ b/thinknode-m7-nettest.yaml
@@ -1,0 +1,184 @@
+# Standalone control for the meshcore DHCP-to-DNS question, so no packages, no Home Assistant API, and no mDNS.
+# ESPHome names the DHCP client from esphome.name, in EthernetComponent::start_connect_() ahead of esp_netif_dhcpc_start().
+# That single call is the delta to compare against, everything else here exists to get the board far enough to make it.
+# Every pin below is transcribed from the meshcore variant and is unverified until this build runs on the hardware.
+
+# https://esphome.io/components/substitutions
+substitutions:
+  device_name: thinknode-m7-nettest
+  device_friendly_name: "ThinkNode M7 Nettest"
+
+# Elecrow ThinkNode M7
+# ESP32-S3 QFN56 rev 0.2, 8MB quad flash, 8MB octal PSRAM, 40MHz crystal.
+# WCH CH343 USB-UART bridge on UART0, so no native USB CDC and no serial adapter needed to flash.
+
+# WCH CH390 SPI ethernet MAC and PHY, reporting vendor 0x1C00 and product 0x9151.
+# GPIO47 : sclk
+# GPIO48 : mosi
+# GPIO14 : miso
+# GPIO21 : cs
+# GPIO45 : interrupt
+# - The variant declares no reset pin, so none is configured.
+
+# GPIO17 : i2c sda
+# GPIO18 : i2c scl
+# GPIO3  : green status LED, active low
+# GPIO46 : blue LoRa TX LED, active low
+# GPIO4  : user button, PIN_USER_BTN_ANA in the variant
+# - GPIO3, GPIO45, and GPIO46 are ESP32-S3 strapping pins, so nothing may hold them at boot.
+
+# Semtech LR1110 LoRa on a second SPI bus, left unconfigured because the question is the network stack.
+# GPIO11 : sclk
+# GPIO9  : miso
+# GPIO10 : mosi
+# GPIO12 : nss
+# GPIO13 : busy
+# GPIO38 : dio1
+# GPIO39 : reset
+
+# https://esphome.io/components/esphome
+esphome:
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
+
+# https://esphome.io/components/esp32
+# A bare ESP32-S3 with external flash, which is the DevKitC-1 profile, there is no WROOM module fitted.
+esp32:
+  board: esp32-s3-devkitc-1
+
+  # The board definition does not set this, ESPHome defaults to 4MB.
+  flash_size: 8MB
+
+  # https://esphome.io/components/esp32#esp-idf-framework
+  framework:
+    type: esp-idf
+
+# https://esphome.io/components/psram
+# 8MB in package on an S3 is octal, and ESPHome has no default mode on this variant.
+psram:
+  mode: octal
+  speed: 80MHz
+
+# https://esphome.io/components/logger
+# UART0 is the CH343 bridge, which is the only way to read this device with no API.
+logger:
+  level: debug # none, error, warn, info, debug, verbose, very_verbose
+  hardware_uart: UART0 # UART0, USB_CDC, USB_SERIAL_JTAG
+
+# https://esphome.io/components/ota
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+# https://esphome.io/components/external_components
+# ESPHome has no CH390 type, so this shadows the core ethernet component with a patched copy that adds it.
+# Local, not `source: github://pr#18226`: that fetches the PR's ethernet component, which is based on dev
+# and imports get_network_priority from the core network component, absent in the installed release.
+# external_components shadows ethernet only, so the dev component meets a release core and the import fails.
+external_components:
+  - source:
+      type: local
+      path: ch390/components
+    components: [ethernet]
+
+# https://esphome.io/components/ethernet
+# domain only builds the OTA target address and has no bearing on the DHCP hostname.
+ethernet:
+  type: CH390
+  clk_pin: GPIO47
+  mosi_pin: GPIO48
+  miso_pin: GPIO14
+  cs_pin: GPIO21
+  interrupt_pin: GPIO45
+  clock_speed: 20MHz
+  domain: !secret wifi_domain
+  on_connect:
+    - light.turn_on: led_blue
+  on_disconnect:
+    - light.turn_off: led_blue
+
+# https://esphome.io/components/mdns
+# Disabled so a name resolves only through the DHCP registered record, which is the thing under test.
+mdns:
+  disabled: true
+
+# https://esphome.io/components/i2c
+# The variant carries an RTC that meshcore finds by autodiscovery, so scan to see what this unit populates.
+i2c:
+  sda: GPIO17
+  scl: GPIO18
+  scan: true
+
+# https://esphome.io/components/output
+output:
+
+  # https://esphome.io/components/output/gpio
+  - platform: gpio
+    id: led_blue_out
+    pin:
+      number: GPIO46
+      inverted: true
+
+# https://esphome.io/components/light
+light:
+
+  # https://esphome.io/components/light/status_led
+  # Both LEDs are driven from firmware state because nothing can reach them with no API.
+  - platform: status_led
+    name: "Green LED"
+    pin:
+      number: GPIO3
+      inverted: true
+
+  # https://esphome.io/components/light/binary
+  # Follows the ethernet link, so a lit blue LED means DHCP handed out an address.
+  - platform: binary
+    name: "Blue LED"
+    id: led_blue
+    output: led_blue_out
+
+# https://esphome.io/components/binary_sensor
+binary_sensor:
+
+  # https://esphome.io/components/binary_sensor/gpio
+  # Treated as a plain pull-up input, which is wrong if the variant's ANA name means an ADC ladder.
+  - platform: gpio
+    name: "User Button"
+    pin:
+      number: GPIO4
+      mode:
+        input: true
+        pullup: true
+      inverted: true
+
+# https://esphome.io/components/sensor
+sensor:
+
+  # https://esphome.io/components/sensor/internal_temperature
+  - platform: internal_temperature
+    name: "Internal Temperature"
+
+  # https://esphome.io/components/sensor/uptime
+  - platform: uptime
+    name: "Uptime"
+    unit_of_measurement: min
+    filters:
+      - lambda: return x / 60.0;
+
+# https://esphome.io/components/text_sensor
+text_sensor:
+
+  # https://esphome.io/components/text_sensor/ethernet_info
+  # These print to the logger on connect, which is the whole readout of the test.
+  - platform: ethernet_info
+    ip_address:
+      name: "IP Address"
+    dns_address:
+      name: "DNS Address"
+    mac_address:
+      name: "MAC Address"
+
+  # https://esphome.io/components/text_sensor/version
+  - platform: version
+    name: "Version"
+    hide_timestamp: true

--- a/thinknode-m7.yaml
+++ b/thinknode-m7.yaml
@@ -1,0 +1,19 @@
+substitutions:
+  device_name: thinknode-m7
+  device_friendly_name: "ThinkNode M7"
+
+packages:
+  thinknode: !include templates/elecrow-thinknode-m7.yaml
+
+# https://esphome.io/components/external_components
+# The template needs the CH390 ethernet type, which ESPHome does not ship yet.
+# Tracked upstream as esphome/esphome#18226, and the block goes away once that merges and releases.
+# A local path resolves against this config's own directory.
+# Local, not `source: github://pr#18226`: that fetches the PR's ethernet component, which is based on dev
+# and imports get_network_priority from the core network component, absent in the installed release.
+# external_components shadows ethernet only, so the dev component meets a release core and the import fails.
+external_components:
+  - source:
+      type: local
+      path: ch390/components
+    components: [ethernet]


### PR DESCRIPTION
Adds the Elecrow ThinkNode M7 as a reusable board template, with the CH390 ethernet support it needs and the diagnostics used to establish the board's hardware identity.

## Why the Vendored Component

ESPHome has no `CH390` ethernet type. The board's controller is a WCH CH390 reporting vendor `0x1C00` and product `0x9151`, and the ESP-IDF DM9051 driver demands `0x0A46` / `0x9051` and rejects it with `wrong Vendor ID`. The register map is DM9051 compatible; the identity gate is not, so the compatibility claim buys nothing on its own.

`ch390/components/ethernet/` is a patched copy of the core component consumed through a local `external_components`, which is what lets the board work against a released ESPHome.

**Upstream support merged on 2026-08-10**: `esphome/esphome#18226` for the code and `esphome/esphome.io#7149` for the documentation, four seconds apart. That lands the support in `dev`, not in a release, so the vendored copy is still what makes this board work today and stays until a release ships carrying it. Its lifetime is now bounded rather than open-ended, and the deletion is a known follow-up rather than a hope.

The two agree on everything CH390: `ethernet_component_esp32.cpp` is byte-identical to upstream `dev` and `ethernet_component.h` differs by a single NOLINT marker pair. `__init__.py` differs by unrelated upstream work that landed after the fork point (network priority plumbing, a `CONFLICTS_WITH` removal), none of it CH390.

A local `external_components` path resolves against the **including config's own directory**, not the repository root, which is why the template documents the requirement and each consumer declares its own path (`ch390/components` at the root, `../ch390/components` from `test/`).

## SPI Clock Ceiling

The shared SPI schema tops out at 80MHz. CH390DS1 v1.8 tables 9-4 and 9-5 give SCK as 50MHz typical and 72MHz maximum with VDDIO at 3.3V, so that ceiling is out of spec for this controller. `SPI_SCHEMA_CH390` caps it at 72MHz, the same shape `ENC28J60` already uses for its own lower limit. The default is unchanged.

This cap is upstream as well, in the merge above, so the vendored schema and ESPHome's own now agree on the ceiling.

The schema default of 26.67MHz is hardware measured rather than assumed: its ICMP loss over two runs sits inside the spread already measured at 20 and 40MHz, so the default is a verified operating point. `dump_config` prints it as `Clock Speed: 26 MHz`, truncating to whole MHz.

## Hardware Verification

Polling mode is verified on the board with the interrupt line left unwired. A 2x2 over mode and clock speed, 10000 full-MTU frames per cell, found no defect specific to polling: loss ran 0.03 to 0.18 percent in every cell, and interrupt mode lost more than polling in one pair, so loss does not track the mode. `thinknode-m7-bench.yaml` carries the measurements and the reasoning in full.

The radio is an LR1110, hardware `0x22`, firmware `0x0303`, read over SPI3. Elecrow documents neither the ethernet controller nor a pinout, so both were established by hand; `thinknode-m7-ethid.yaml` and `thinknode-m7-loraid.yaml` are the probes that did it.

## Notes

- No `DEVICES.md` entry: everything listed there is deployed, and this is bench hardware. Whether it earns a bench section is a separate call.
- `test/elecrow-thinknode-m7.yaml` adds a leg to the template compile matrix, so the template is known to build against the current release.
