### PR TITLE
Run the lint gate on a pull request into develop

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -8,12 +8,18 @@ name: Test pull request action
 # - develop takes direct signed commits, where push runs advisory CI.
 # - main is the promoted snapshot, where the develop -> main promotion PR runs the enforced gate.
 # - check-workflow-status is the ruleset-bound required check, rename it and the ruleset context together.
+# The pull_request branch set names both, since naming main alone matches nothing on a PR into develop.
+# That leaves the validation job unstarted and the aggregator unreported.
+# The PR then reads mergeable with an empty check list, the false clean WORKFLOW.md D1.2 forbids.
+# The duplicate run it costs, once on the PR and again on the push when the merge lands, is accepted.
+# The concurrency group keys on github.ref, and the two runs sit in different groups.
+# A pull_request run is refs/pull/<n>/merge where the push run is refs/heads/develop, so neither cancels the other.
 
 on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Resync against `ptr727/ProjectTemplate` `main@0e84805`. Drift class 3 of 3: the interface workflow.

## The defect

`test-pull-request.yml` named `pull_request: branches: [ main ]`. A pull request opened against `develop` matches nothing in that set, so the validation job never starts and the aggregator never reports. The pull request then shows a mergeable state with an empty check list, which reads as a clean pass and is the outcome `WORKFLOW.md` D1.2 forbids. The hub's operational-model section names a `main`-only trigger set as a defect outright.

The trigger set now names both branches.

## What it does not change

The `develop` ruleset requires no status check, so the gate is reported there rather than required. The direct-commit allowance the operational model is built on stays intact.

## The cost

A duplicate run: once on the pull request, and again on the push when the merge lands. The two occupy different concurrency groups, since the group keys on `github.ref` and a `pull_request` run is `refs/pull/<n>/merge` where the push run is `refs/heads/develop`, so neither cancels the other. On a lint-only gate that is a couple of runner-minutes, and the alternative, a condition that suppresses the push run, would have to tell a merge commit from a direct commit.

## Verification

`actionlint` (which bundles shellcheck for the `run:` blocks) and the hub `prose_lint.py` over the changed lines, both clean. The trigger itself is exercised by the first pull request that opens against `develop`, which is this one's siblings.
