### PR TITLE
Sort the one link definition pair that orders by line, not by name

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -85,8 +85,8 @@ The remaining ESP32 devices are clear: the [garage presence sensor][garage-prese
 [templates]: ./templates/
 [unexpectedmaker-pros3d]: ./templates/unexpectedmaker-pros3d.yaml
 [upstairs-hallway-plant-sensor]: ./upstairs-hallway-plant-sensor.yaml
-[waveshare-esp32-s3-eth-camera]: ./templates/waveshare-esp32-s3-eth-camera.yaml
 [waveshare-esp32-s3-eth]: ./templates/waveshare-esp32-s3-eth.yaml
+[waveshare-esp32-s3-eth-camera]: ./templates/waveshare-esp32-s3-eth-camera.yaml
 
 <!-- External -->
 


### PR DESCRIPTION
The fleet rule alphabetizes a reference-definition group **by bare reference name**, so a name that is a prefix of another sorts first, `[governance]` above `[governance-branching-model]`. `DEVICES.md` had the one prefix pair in the repository ordered the other way:

```text
[waveshare-esp32-s3-eth-camera]: ./templates/waveshare-esp32-s3-eth-camera.yaml
[waveshare-esp32-s3-eth]: ./templates/waveshare-esp32-s3-eth.yaml
```

That is what sorting the **full definition line** produces, since `-` (0x2D) precedes `]` (0x5D). Two lines swapped.

Every other definition group in the repository already sorts by name: `OPERATIONS.md`, `README.md`, `CODESTYLE.md`, `AUDIT.md` and `WORKFLOW.md` across all their groups, and `DEVICES.md`'s own External group.

Checked **per group**, keyed on the label with its brackets stripped. A check spanning two groups reports a false disorder at the boundary between them, and a check keyed on the label with brackets attached gets the prefix pair backwards, which is how this one was previously recorded as correct.
