### PR TITLE
Run the lint snapshot container as the host UID, not chmod'ed

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -39,11 +39,12 @@ does report both as a **drift finding**.
 ## Secrets
 
 This repo carries no local `spec/secrets.json` either, for the same reason: the required and
-forbidden name lists resolve centrally from the registry entry (`publish[]` and `types[]`) rather
-than from anything repo-specific, so a per-repo copy could only restate the hub's own computation
-or drift from it. This repo declares `requiredSecrets: []` and `publish: [{ "target":
-"github-release", "mechanism": "none" }]` in the hub's registry, which resolves to no required
-secret beyond the fleet baseline. Confirm it from a hub checkout at `main`:
+forbidden name lists resolve centrally from the registry entry (`publish[]`, `types[]`, and its
+own `requiredSecrets[]`) rather than from anything repo-specific, so a per-repo copy could only
+restate the hub's own computation or drift from it. This repo declares `requiredSecrets: []` and
+`publish: [{ "target": "github-release", "mechanism": "none" }]` in the hub's registry, which
+resolves to no required secret beyond the fleet baseline. Confirm it from a hub checkout at
+`main`:
 
 ```sh
 python3 spec/audit.py ESPHome-Config

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -493,10 +493,7 @@ Sharp edges in the tooling around this repository, each one learned by tripping 
   docker run --rm --network=none --user "$(id -u):$(id -g)" -v "$lint_root":/workdir:ro --workdir /workdir <lint-image> <arguments>
   ```
 
-  `--user "$(id -u):$(id -g)"` runs the container as the invoking host user rather than the
-  image's own default, so it reads `$lint_root` through the same owner permission bits `mktemp
-  -d`'s default `0700` already grants, with no `chmod` opening it to any other local account. The
-  trap removes the snapshot on exit either way.
+  `--user "$(id -u):$(id -g)"` runs the container as the invoking host user rather than the image's own default, so it reads `$lint_root` through the same owner permission bits `mktemp -d`'s default `0700` already grants, with no `chmod` opening it to any other local account. This assumes a standard rootful Docker daemon, where the container's user namespace is the host's own. Under **rootless** Docker the daemon runs in its own user namespace, so the host UID passed to `--user` maps to an unrelated subordinate UID inside the container rather than to the owner of the bind mount, and the snapshot becomes unreadable instead. On a rootless daemon, `chmod -R o+rX "$lint_root"` after the tar step is the fallback, accepting the wider local-account readability for the run's duration. The trap removes the snapshot on exit either way.
 
   **This includes the hub's `scripts/docker_lint.py` wrapper, and it cannot currently take this snapshot as its `--root`.** Its own target discovery runs `git -C "$root" ls-files`, and the snapshot above deliberately holds only the `git ls-files` output, not `.git` itself, so `--root "$lint_root"` fails with "not a git repository" before any linter runs. Passing the live checkout instead would defeat the whole point of the snapshot. Until the wrapper accepts a plain snapshot or file manifest (tracked upstream as [ptr727/ProjectTemplate#1090][hub-issue-1090]), lint this repository with the direct `docker run` invocations above rather than `docker_lint.py`.
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -485,18 +485,18 @@ Sharp edges in the tooling around this repository, each one learned by tripping 
 - **Never mount the live checkout into a third-party lint container.** `secrets.yaml` holds the live secrets and is git-ignored. [`secrets._yaml`][secrets-example] is the tracked placeholder. Build a temporary snapshot from tracked and intended untracked files, mount that snapshot read-only, and remove it when done. The Git exclusion rules keep `secrets.yaml` out without maintaining a second exclusion list.
 
   ```shell
+  set -Eeuo pipefail
   repo_root="$(git rev-parse --show-toplevel)"
   lint_root="$(mktemp -d /tmp/esphome-lint.XXXXXX)"
   trap 'rm -rf "$lint_root"' EXIT
   git -C "$repo_root" ls-files --cached --others --exclude-standard -z | tar -C "$repo_root" --null -T - -cf - | tar -xf - -C "$lint_root"
-  chmod -R o+rX "$lint_root"
-  docker run --rm --network=none -v "$lint_root":/workdir:ro --workdir /workdir <lint-image> <arguments>
+  docker run --rm --network=none --user "$(id -u):$(id -g)" -v "$lint_root":/workdir:ro --workdir /workdir <lint-image> <arguments>
   ```
 
-  `chmod -R o+rX` stays: `mktemp -d`'s default `0700` blocks a lint container running as a
-  non-matching, non-root UID (the common case for these images) from reading the mount at all,
-  and the trap now removes the snapshot regardless, so the readable window is only the lint run
-  itself on a single-tenant CI runner or dev host.
+  `--user "$(id -u):$(id -g)"` runs the container as the invoking host user rather than the
+  image's own default, so it reads `$lint_root` through the same owner permission bits `mktemp
+  -d`'s default `0700` already grants, with no `chmod` opening it to any other local account. The
+  trap removes the snapshot on exit either way.
 
   **This includes the hub's `scripts/docker_lint.py` wrapper, and it cannot currently take this snapshot as its `--root`.** Its own target discovery runs `git -C "$root" ls-files`, and the snapshot above deliberately holds only the `git ls-files` output, not `.git` itself, so `--root "$lint_root"` fails with "not a git repository" before any linter runs. Passing the live checkout instead would defeat the whole point of the snapshot. Until the wrapper accepts a plain snapshot or file manifest (tracked upstream as [ptr727/ProjectTemplate#1090][hub-issue-1090]), lint this repository with the direct `docker run` invocations above rather than `docker_lint.py`.
 


### PR DESCRIPTION
## Summary

Two more corrections from #116's review round:

- `OPERATIONS.md`: replaces `chmod -R o+rX "$lint_root"` (world-readable to every local account)
  with `docker run --user "$(id -u):$(id -g)"`, so the lint container reads the snapshot through
  the same owner permission bits `mktemp -d`'s default `0700` already grants. Verified end to end
  against a real container (`alpine:latest`, mode `0700`, non-empty listing). Also adds `set
  -Eeuo pipefail` to the recipe, per the fleet's shell convention, so a failed `ls-files`/`tar`
  stage stops the pipeline instead of silently running Docker on a partial snapshot.
- `AUDIT.md`: names `requiredSecrets[]` alongside `publish[]` and `types[]` as an input to the
  Secrets check, matching what the hub audit actually reads from the registry entry.

Verified locally: `prose_lint.py --diff aa192d2 -- .` reports zero violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated secret-handling guidance to include all required secret names defined by registry entries.
  * Improved container linting instructions to preserve file permissions and run with the invoking user’s access.
  * Retained automatic cleanup after linting and read-only snapshot access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->