### PR TITLE
Replace deprecated rgb_order with channel_colors

### DIFF
--- a/templates/rgb-led-status.yaml
+++ b/templates/rgb-led-status.yaml
@@ -92,7 +92,7 @@ light:
     id: system_status_led
     name: "Status LED"
     pin: ${rgb_led_pin}
-    rgb_order: GRB
+    channel_colors: GRB
     num_leds: 1
     chipset: WS2812
     disabled_by_default: true


### PR DESCRIPTION
Resolves the deprecation warning reported in #125.

ESPHome 2026.8.0 added `channel_colors` to the light schema and deprecated `rgb_order`, `is_rgbw` and `is_wrgb`, scheduled for removal in 2027.3.0. Validation folded `rgb_order: GRB` into `channel_colors: GRB` and logged a warning on every config and compile of a device composing the template.

The two forms are equivalent here. `light.migrate_channel_colors` maps a bare `rgb_order` with no `is_rgbw` or `is_wrgb` straight through, so the generated `light::ChannelColors` struct is unchanged.

## Verification

Ran against ESPHome 2026.8.2 in the `esphome` container, on a snapshot of this branch under the `/cache` mount so the live `/config` tree was not touched.

- Baseline on `develop` reproduces the warning on `hvac-compressor-sensor`, and it is gone on this branch.
- `esphome config` is valid with no `rgb_order` warning on the four templates that compose this one: `test/unexpectedmaker-pros3d`, `test/adafruit-esp32-s3-feather`, `test/esp32-s3-devkitc`, `test/waveshare-esp32-s3-eth`.
- `esphome config` is valid on the live consumers: `hvac-compressor-sensor`, `office-bluetooth-proxy`, `pantry-bluetooth-proxy`, `ble-notify-race-test`.
- The remaining GPIO3 strapping warning on the Adafruit Feather is pre-existing and unrelated to this change.

## Note

`channel_colors` first ships in ESPHome 2026.8.0, so this raises the template's floor to that release. The template is advertised as a remote package in `README.md` and `OPERATIONS.md`, and a consumer on an older ESPHome now fails validation rather than logging a warning. Documenting or enforcing that floor is deliberately left out of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated RGB LED strip configuration to use the supported channel color mapping format.
  - Preserved the existing GRB color order for accurate LED color output.
  - Improved compatibility with current LED strip platform configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->