### PR TITLE
Remove the dead easystart compile-test CI job

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,9 +1,9 @@
 name: Test pull request action
 
-# Source lint plus change-gated compile tests, run on the ptr727/esphome-nonroot image the repo deploys.
-# - compile-test builds the easystart external component, whose C++ and codegen only fail at compile time.
+# Source lint plus a change-gated compile test, run on the ptr727/esphome-nonroot image the repo deploys.
 # - template-compile-test builds one example device per published template, so nothing ships that cannot build.
-# Both cost minutes of esp-idf build, so each runs only when what it covers moves.
+# - test/easystart.yaml is one such example device, so it also covers the easystart external component.
+# It costs minutes of esp-idf build, so it runs only when what it covers moves.
 # Operational model.
 # - develop takes direct signed commits, where push runs advisory CI.
 # - main is the promoted snapshot, where the develop -> main promotion PR runs the enforced gate.
@@ -36,8 +36,8 @@ jobs:
     permissions:
       contents: read
 
-  # Change gate for the compile tests, plus the template matrix definition.
-  # An esp-idf build costs minutes, so gate on what each test covers.
+  # Change gate for the compile test, plus the template matrix definition.
+  # An esp-idf build costs minutes, so gate on what the test covers.
   # An undeterminable diff runs everything.
   changes:
     name: Detect build-affecting changes job
@@ -45,7 +45,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      compile-test: ${{ steps.filter.outputs.compile-test }}
       template-test: ${{ steps.filter.outputs.template-test }}
       template-configs: ${{ steps.configs.outputs.template-configs }}
 
@@ -66,7 +65,6 @@ jobs:
         run: |
           set -Eeuo pipefail
           run_all() {
-            echo "compile-test=true" >> "$GITHUB_OUTPUT"
             echo "template-test=true" >> "$GITHUB_OUTPUT"
             exit 0
           }
@@ -79,12 +77,6 @@ jobs:
             run_all
           fi
           WORKFLOW='\.github/workflows/test-pull-request\.yml$'
-          # ble-notify-race-test.yaml is a root device config, so it needs its own pattern.
-          if grep -qE "^(easystart/components/|easystart/test/|ble-notify-race-test\.yaml$|$WORKFLOW)" <<<"$DIFF"; then
-            echo "compile-test=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "compile-test=false" >> "$GITHUB_OUTPUT"
-          fi
           # test/ hosts the example devices, and test/easystart.yaml compiles easystart/components.
           if grep -qE "^(templates/|test/|easystart/components/|$WORKFLOW)" <<<"$DIFF"; then
             echo "template-test=true" >> "$GITHUB_OUTPUT"
@@ -114,48 +106,6 @@ jobs:
           CONFIGS="$(basename -a -s .yaml test/*.yaml | jq -Rsc 'split("\n") | map(select(length > 0))')"
           echo "Template matrix: $CONFIGS"
           echo "template-configs=$CONFIGS" >> "$GITHUB_OUTPUT"
-
-  # Compile the easystart component in the deployment image, ptr727/esphome-nonroot.
-  # The build tree and HOME live under the world-writable /cache mount that the image's cache.sh initializes.
-  # /config is the repo, so the test config's `path: ../components` resolves to the real component source.
-  compile-test:
-    name: Compile test job
-    runs-on: ubuntu-latest
-    needs: [ changes ]
-    if: ${{ needs.changes.outputs.compile-test == 'true' }}
-    permissions:
-      contents: read
-
-    steps:
-
-      - name: Checkout code step
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      # ble-notify-race-test.yaml resolves !secret through the board template, so it needs the dummy set.
-      # The encryption key is generated here, so no usable key is committed.
-      - name: Create dummy secrets step
-        run: |
-          set -Eeuo pipefail
-          cp secrets._yaml secrets.yaml
-          sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$(openssl rand -base64 32)|" secrets.yaml
-
-      - name: Compile easystart test config step
-        run: |
-          set -Eeuo pipefail
-          cache="$(mktemp -d)"
-          chmod -R 0777 "$cache" .
-          docker run --rm --user 1000:1000 \
-            --volume "$PWD":/config \
-            --volume "$cache":/cache \
-            ptr727/esphome-nonroot:latest \
-            bash -c '
-              set -Eeuo pipefail
-              /entrypoint/cache.sh
-              esphome config /config/easystart/test/compile-test.yaml > /dev/null
-              esphome compile /config/easystart/test/compile-test.yaml
-              esphome config /config/ble-notify-race-test.yaml > /dev/null
-              esphome compile /config/ble-notify-race-test.yaml
-            '
 
   # Compile one example device per published template.
   # test/ holds the configs, and the Device Builder scan is non-recursive, so they are not listed as devices.
@@ -209,7 +159,7 @@ jobs:
   check-workflow-status:
     name: Check pull request workflow status job
     runs-on: ubuntu-latest
-    needs: [ validate, changes, compile-test, template-compile-test ]
+    needs: [ validate, changes, template-compile-test ]
     if: always()
     steps:
       - name: Check workflow results step
@@ -223,13 +173,9 @@ jobs:
             echo "Job 'changes' did not succeed (${{ needs.changes.result }}); refusing to pass."
             exit 1
           fi
-          # The compile jobs are skipped when the change gate says nothing they cover moved.
+          # The compile job is skipped when the change gate says nothing it covers moved.
           # Only a real failure blocks, a skip must still pass.
           # The matrix aggregates to a single result, failure if any leg failed.
-          if [[ "${{ needs.compile-test.result }}" == "failure" ]]; then
-            echo "Job 'compile-test' failed; refusing to pass."
-            exit 1
-          fi
           if [[ "${{ needs.template-compile-test.result }}" == "failure" ]]; then
             echo "Job 'template-compile-test' failed; refusing to pass."
             exit 1

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -116,7 +116,7 @@ Do not raise `api: max_connections` to paper over leaked sessions. Five is plent
 - **Scan parameters stay at the ESPHome defaults.** `interval` 320ms, `window` 30ms, and `active: true` are what upstream's own proxy configs ship. The [`bluetooth_proxy` docs][bluetooth-proxy-link] name a full duty cycle, `interval` and `window` both 1100ms, as an anti-pattern that adds CPU load and heat for no gain, and on a WiFi-connected board it also fights the shared radio. It competes with the connection events of any `ble_client` on the same device, so the cost lands where it hurts most.
 - **Passive scanning is enough to reach a known MAC.** A device whose only BLE job is connecting to `ble_client` targets parses no advertisement payloads, so `active: false` drops the scan-request transmissions with nothing lost.
 - **`ble_client` depends on `esp32_ble_tracker`, and needs it scanning.** The tracker is a hard dependency, and a client only connects once a scan discovers its address. Continuous scanning is the sole path back after a disconnect, so `continuous: false` strands a dropped module until something else starts a scan.
-- **A `ble_client` automation action registers itself as a BLE node, and most never report `ESTABLISHED`.** `ble_client.disconnect`, `ble_client.connect`, and the other actions in ESPHome's `ble_client/automation.h` call `register_ble_node(this)` from their constructors, and their handlers return early while `num_running_ == 0`. `BLEClientDisconnectAction` never assigns `node_state` at all. Since `BLEClient` releases its cached services only once *every* node reports `ESTABLISHED`, a single such action anywhere in a config suppresses that release for the whole client, so the service memory is never reclaimed. Use a `lambda` calling `id(client)->disconnect()` when the action's own completion semantics are not needed. This also masks the crash described in [`easystart/ESPHOME-BLE-ISSUE.md`][ble-issue], which is why it took a component without any such action to surface it.
+- **A `ble_client` automation action registers itself as a BLE node, and most never report `ESTABLISHED`.** `ble_client.disconnect`, `ble_client.connect`, and the other actions in ESPHome's `ble_client/automation.h` call `register_ble_node(this)` from their constructors, and their handlers return early while `num_running_ == 0`. `BLEClientDisconnectAction` never assigns `node_state` at all. Since `BLEClient` releases its cached services only once *every* node reports `ESTABLISHED`, a single such action anywhere in a config suppresses that release for the whole client, so the service memory is never reclaimed. Use a `lambda` calling `id(client)->disconnect()` when the action's own completion semantics are not needed. This also masks the ble_client GATT-cache race described in [upstream issue #17921][ble-release-services-bug], which is why it took a component without any such action to surface it.
 - **A flashing status LED on a device with a `ble_client` is usually not a fault.** The `ble_client` RSSI sensor calls `status_set_warning()` on `ESP_GATTC_CLOSE_EVT`, and `status_led` blinks on any component warning. An EasyStart module holds its BLE link only while its compressor runs, so the LED flashes for as long as a compressor is idle, which is most of the time. Judge link quality by the RSSI value and its history, never by the LED.
 
 ## Strapping Pin Warnings
@@ -523,7 +523,6 @@ Sharp edges in the tooling around this repository, each one learned by tripping 
 [api-connection-cap]: #logs-and-the-api-connection-cap
 [apollo-template]: ./templates/apollo-plt-1b.yaml
 [audit-general-settings-and-rulesets]: ./AUDIT.md#general-settings-and-rulesets
-[ble-issue]: ./easystart/ESPHOME-BLE-ISSUE.md
 [ble-re-playbook]: ./easystart/BLE-RE-PLAYBOOK.md
 [ceilsense-template]: ./templates/smarthome-ceilsense.yaml
 [codestyle]: ./CODESTYLE.md
@@ -559,6 +558,7 @@ Sharp edges in the tooling around this repository, each one learned by tripping 
 
 <!-- External -->
 
+[ble-release-services-bug]: https://github.com/esphome/esphome/issues/17921
 [bluetooth-proxy-link]: https://esphome.io/components/bluetooth_proxy
 [dashboard-link]: http://localhost:6052/
 [devices-esphome-link]: https://devices.esphome.io

--- a/secrets._yaml
+++ b/secrets._yaml
@@ -8,7 +8,7 @@ wifi_domain: ".local"
 api_encryption_key: "REPLACE_WITH_BASE64_32_BYTE_KEY"
 ota_password: "password"
 
-# Micro-Air EasyStart module BLE MACs, used by hvac-compressor-sensor.yaml and ble-notify-race-test.yaml.
+# Micro-Air EasyStart module BLE MACs, used by hvac-compressor-sensor.yaml.
 # Discover your own with: uv run easystart/python/easystart_monitor.py --discover
 easystart_downstairs_mac: "AA:BB:CC:DD:EE:01"
 easystart_upstairs_mac: "AA:BB:CC:DD:EE:02"


### PR DESCRIPTION
## Summary

Removes the dead `compile-test` CI job from `.github/workflows/test-pull-request.yml`.
Two earlier develop commits deleted the configs it compiled
(`easystart/test/compile-test.yaml`, `ble-notify-race-test.yaml`) without updating the
workflow, which left the required `Check pull request workflow status job` gate
failing on every push and blocked the develop -> main promotion PR (#131).

The easystart external component is still compiled via the existing
`template-compile-test` matrix, through `test/easystart.yaml`, so no coverage is lost.

Also cleans up two stale references the same deletions left behind: an `OPERATIONS.md`
link to the removed `ESPHOME-BLE-ISSUE.md` (replaced with the filed upstream issue
link), and a `secrets._yaml` comment naming the removed `ble-notify-race-test.yaml`.

## Verification

- `actionlint` passes.
- Local strict review (adversarial pass, full diff, two rounds): two findings raised
  and fixed (a misplaced/misordered Markdown link reference, a malformed comment
  continuation), then reverified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
