### PR TITLE
Drop the invalid nuget input from publish-release.yml

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,7 +55,6 @@ jobs:
       branch: ${{ github.ref_name }}
       smoke: false
       github: true
-      nuget: false
       dockerhub: false
       enable_docker: false
       enable_nuget: false


### PR DESCRIPTION
## Summary

Removes the invalid `nuget: false` input from `.github/workflows/publish-release.yml`'s
`publish` job. The hub's `build-release-task.yml` dropped its top-level `nuget`
push-gate input between hub 2.0.518 (this repo's last successful release) and 2.0.539
(the version an earlier automated pin bump moved this repo to), in favor of a
caller-owned `publish-nuget` job pattern.

Passing an undeclared input to a `workflow_call` is rejected by GitHub Actions at
parse time with zero jobs created. Dispatching a release just now failed exactly
this way: run [33976981014](https://github.com/ptr727/ESPHome-Config/actions/runs/33976981014),
`startup_failure`, empty jobs array.

This repo has no NuGet target (`enable_nuget: false` already says so), so the fix is
to drop the stale input. Confirmed against the hub's own reference caller stub at the
identical pinned commit, which carries an equivalent `with:` block with no `nuget` key.

## Verification

- `actionlint` passes.
- Local strict review (adversarial pass): independently re-derived the hub's full
  input schema at the pinned commit and confirmed every remaining `with:` key is
  valid and the one required input (`branch`) is present; confirmed no other file in
  the repo passes a `nuget` boolean anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
