### PR TITLE
Promote Develop to Main

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,7 +55,6 @@ jobs:
       branch: ${{ github.ref_name }}
       smoke: false
       github: true
-      nuget: false
       dockerhub: false
       enable_docker: false
       enable_nuget: false


### PR DESCRIPTION
## Summary

Promote the current operational `develop` snapshot to `main`.

Single commit since the last promotion (#131): fixes the release-dispatch bug that
#131's own follow-on release attempt hit (an invalid `nuget` input to the hub's
`build-release-task.yml` at its current pinned version, causing every release
dispatch to fail at parse time with zero jobs run).

## Promotion facts

- develop head: `a8c544bdf3afacbdfdc62111de69f7faf721f7f6`
- 1 develop commit since the merge-base
- merge method: merge commit only
- keep `develop`; never delete the promotion head

The promotion gate validates the combined main/develop merge ref before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
